### PR TITLE
originalFaultCode management

### DIFF
--- a/src/controllers/restful/PaymentController.ts
+++ b/src/controllers/restful/PaymentController.ts
@@ -410,10 +410,11 @@ export function getResponseErrorIfExists(
   if (faultBean === undefined) {
     return undefined;
   }
-  // Response is FAILED and additional information are provided by PagoPa
   return getErrorMessageCtrlFromPagoPaError(
+    faultBean.id,
     faultBean.faultCode,
-    faultBean.description
+    faultBean.description,
+    faultBean.originalFaultCode
   );
 }
 
@@ -421,14 +422,34 @@ export function getResponseErrorIfExists(
  * Convert PagoPa message error (faultCode) to Controller message error (ErrorMessagesCtrlEnum) to send to BackendApp
  * A complete list of faultCode provided by PagoPa is available at
  * https://www.agid.gov.it/sites/default/files/repository_files/specifiche_attuative_nodo_2_1_0.pdf
+ * @param {string} faultId - Error Id provided by PagoPa to
  * @param {string} faultCode - Error code provided by PagoPa
  * @return {PaymentFaultEnum} Error code to send to BackendApp
  */
 export function getErrorMessageCtrlFromPagoPaError(
+  faultId: string,
   faultCode: string,
-  faultDescription: string | undefined
+  faultDescription: string | undefined,
+  originalFaultCode: string | undefined
 ): PaymentFaultEnum {
   switch (faultCode) {
+    case "PPT_EMESSO_DA_PAA":
+      return getErrorMessageFromPA(originalFaultCode);
+    case "PPT_DOMINIO_SCONOSCIUTO":
+      return PaymentFaultEnum.DOMAIN_UNKNOWN;
+    default:
+      // faultCode doesn't match anything
+      logger.warn(
+        `Retrieved a generic PagoPA error from ${faultId} response: (FaultCode: ${faultCode} - Description: ${faultDescription})`
+      );
+      return PaymentFaultEnum.PAYMENT_UNAVAILABLE;
+  }
+}
+
+function getErrorMessageFromPA(
+  originalFaultCode: string | undefined
+): PaymentFaultEnum {
+  switch (originalFaultCode) {
     case "PAA_ATTIVA_RPT_IMPORTO_NON_VALIDO":
       return PaymentFaultEnum.INVALID_AMOUNT;
     case "PAA_PAGAMENTO_DUPLICATO":
@@ -443,20 +464,7 @@ export function getErrorMessageCtrlFromPagoPaError(
       return PaymentFaultEnum.DOMAIN_UNKNOWN;
     default:
       // faultCode doesn't match anything
-      if (faultDescription !== undefined) {
-        // if there's a description, try to look for a fault code in the
-        // description
-        const extractedFaultCode = faultDescription.match(/(PAA|PPT)_\S+/);
-        if (extractedFaultCode !== null) {
-          return getErrorMessageCtrlFromPagoPaError(
-            extractedFaultCode[0],
-            undefined
-          );
-        }
-      }
-      logger.warn(
-        `Retrieved a generic PagoPA error response: (FaultCode: ${faultCode} - Description: ${faultDescription})`
-      );
+      logger.warn(`Unexected originalFaultCode : ${originalFaultCode} from PA`);
       return PaymentFaultEnum.PAYMENT_UNAVAILABLE;
   }
 }

--- a/src/utils/__tests__/MockedData.ts
+++ b/src/utils/__tests__/MockedData.ts
@@ -48,7 +48,7 @@ export const aVerificaRPTOutputKOGeneric = esitoNodoVerificaRPTRisposta_ppt
     esito: "KO",
     fault: {
       id: "NodoDeiPagamentiSPC",
-      faultCode: "CANALE_RICHIEDENTE_ERRATO",
+      faultCode: "PPT_DOMINIO_SCONOCIUTO",
       faultString: "Identificativo richiedente non valido."
     }
   })
@@ -64,9 +64,11 @@ export const aVerificaRPTOutputKOCompleted = esitoNodoVerificaRPTRisposta_ppt
   .decode({
     esito: "KO",
     fault: {
-      id: "NodoDeiPagamentiSPC",
-      faultCode: "PAA_PAGAMENTO_DUPLICATO",
-      faultString: "Pagamento in attesa risulta concluso all’Ente Creditore."
+      id: "NodoDeiPagamentiSP",
+      faultCode: "PPT_EMESSO_DA_PAA",
+      faultString: "Errore emesso da Entre Creditore",
+      originalFaultCode: "PAA_PAGAMENTO_DUPLICATO",
+      originalFaultString: "Pagamento duplicato."
     }
   })
   .getOrElseL(errors => {
@@ -82,8 +84,11 @@ export const aVerificaRPTOutputKOOnGoing = esitoNodoVerificaRPTRisposta_ppt
     esito: "KO",
     fault: {
       id: "NodoDeiPagamentiSPC",
-      faultCode: "PAA_PAGAMENTO_IN_CORSO",
-      faultString: "Pagamento in attesa risulta in corso all’Ente Creditore."
+      faultCode: "PPT_EMESSO_DA_PAA",
+      faultString: "Errore emesso da Ente Creditore",
+      originalFaultCode: "PAA_PAGAMENTO_IN_CORSO",
+      originalFaultString:
+        "Pagamento in attesa risulta in corso all'Ente Creditore"
     }
   })
   .getOrElseL(errors => {
@@ -99,8 +104,10 @@ export const aVerificaRPTOutputKOExpired = esitoNodoVerificaRPTRisposta_ppt
     esito: "KO",
     fault: {
       id: "NodoDeiPagamentiSPC",
-      faultCode: "PAA_PAGAMENTO_SCADUTO",
-      faultString: "Pagamento in attesa risulta scaduto all’Ente Creditore."
+      faultCode: "PPT_EMESSO_DA_PAA",
+      faultString: "Errore emesso da Ente Creditore.",
+      originalFaultCode: "PAA_PAGAMENTO_SCADUTO",
+      originalFaultString: "Pagamento scaduto."
     }
   })
   .getOrElseL(errors => {
@@ -150,24 +157,12 @@ export const aAttivaRPTOutputKOAmount = esitoNodoAttivaRPTRisposta_ppt
     esito: "KO",
     fault: {
       id: "NodoDeiPagamentiSPC",
-      faultCode: "PAA_ATTIVA_RPT_IMPORTO_NON_VALIDO",
-      faultString:
+      faultCode: "PPT_ERRORE_EMESSO_DA_PAA",
+      faultString: "Errore emesso dall'Ente Creditore",
+      originalFaultCode: "PAA_ATTIVA_RPT_IMPORTO_NON_VALIDO",
+      orginalfaultString:
         "L’importo del pagamento in attesa non è congruente con il dato indicato dal PSP"
     }
-  })
-  .getOrElseL(errors => {
-    throw Error(
-      `Invalid esitoNodoAttivaRPTRisposta_ppt to decode: ${reporters.readableReport(
-        errors
-      )}`
-    );
-  });
-
-export const aAttivaRPTOutputKOGeneric = esitoNodoAttivaRPTRisposta_ppt
-  .decode({
-    esito: "KO",
-    faultCode: "PAA_TIPOFIRMA_SCONOSCIUTO",
-    faultString: "Il campo tipoFirma non corrisponde ad alcun valore previsto."
   })
   .getOrElseL(errors => {
     throw Error(

--- a/src/utils/__tests__/PaymentConverter.test.ts
+++ b/src/utils/__tests__/PaymentConverter.test.ts
@@ -351,8 +351,10 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
       return;
     }
     const errorMsg = PaymentController.getErrorMessageCtrlFromPagoPaError(
+      fault.id,
       fault.faultCode,
-      undefined
+      undefined,
+      fault.originalFaultCode
     );
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_DUPLICATED);
@@ -364,10 +366,10 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
       return;
     }
     const errorMsg = PaymentController.getErrorMessageCtrlFromPagoPaError(
-      "",
-      `FaultCode PA: ${
-        fault.faultCode
-      } FaultString PA: Pagamento in attesa risulta in corso all’Ente Creditore. Description PA: `
+      fault.id,
+      fault.faultCode,
+      fault.faultString,
+      fault.originalFaultCode
     );
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_DUPLICATED);
@@ -379,8 +381,10 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
       return;
     }
     const errorMsg = PaymentController.getErrorMessageCtrlFromPagoPaError(
+      fault.id,
       fault.faultCode,
-      undefined
+      undefined,
+      fault.originalFaultCode
     );
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_EXPIRED);
@@ -392,10 +396,10 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
       return;
     }
     const errorMsg = PaymentController.getErrorMessageCtrlFromPagoPaError(
-      "",
-      `FaultCode PA: ${
-        fault.faultCode
-      } FaultString PA: Pagamento in attesa risulta in corso all’Ente Creditore. Description PA: `
+      fault.id,
+      fault.faultCode,
+      fault.faultString,
+      fault.originalFaultCode
     );
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_EXPIRED);
@@ -407,8 +411,10 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
       return;
     }
     const errorMsg = PaymentController.getErrorMessageCtrlFromPagoPaError(
+      fault.id,
       fault.faultCode,
-      undefined
+      undefined,
+      fault.originalFaultCode
     );
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_ONGOING);
@@ -420,10 +426,10 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
       return;
     }
     const errorMsg = PaymentController.getErrorMessageCtrlFromPagoPaError(
-      "",
-      `FaultCode PA:  ${
-        fault.faultCode
-      } FaultString PA: Pagamento in attesa risulta in corso all’Ente Creditore. Description PA: `
+      fault.id,
+      fault.faultCode,
+      fault.faultString,
+      fault.originalFaultCode
     );
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_ONGOING);
@@ -435,8 +441,10 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
       return;
     }
     const errorMsg = PaymentController.getErrorMessageCtrlFromPagoPaError(
+      fault.id,
       fault.faultCode,
-      undefined
+      undefined,
+      fault.originalFaultCode
     );
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_UNAVAILABLE);
@@ -448,8 +456,10 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
       return;
     }
     const errorMsg = PaymentController.getErrorMessageCtrlFromPagoPaError(
+      fault.id,
       fault.faultCode,
-      "Pagamento in attesa risulta in corso all’Ente Creditore. "
+      fault.faultString,
+      fault.originalFaultCode
     );
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_UNAVAILABLE);

--- a/src/wsdl/NodoPerPsp.wsdl
+++ b/src/wsdl/NodoPerPsp.wsdl
@@ -82,6 +82,9 @@
 					<xsd:element name="id" type="xsd:string" />
 					<xsd:element name="description" type="xsd:string" minOccurs="0" />
 					<xsd:element name="serial" type="xsd:int" minOccurs="0" />
+					<xsd:element name="originalFaultCode" type="xsd:string"  minOccurs="0"  />
+					<xsd:element name="originalFaultString" type="xsd:string"  minOccurs="0"  />
+					<xsd:element name="originalDescription" type="xsd:string" minOccurs="0" />
 				</xsd:sequence>
 			</xsd:complexType>
 
@@ -209,7 +212,7 @@
 				<xsd:complexContent>
 					<xsd:extension base="ppt:risposta">
 						<xsd:sequence>
-							<xsd:element name="esito" type="xsd:string" minOccurs="0" />
+							<xsd:element name="esito" type="xsd:string" minOccurs="1" />
 							<xsd:element name="datiPagamentoPA" type="ppt:nodoTipoDatiPagamentoPA" minOccurs="0" />
 						</xsd:sequence>
 					</xsd:extension>
@@ -219,8 +222,8 @@
 			<xsd:complexType name="nodoInviaFlussoRendicontazione">
 				<xsd:sequence>
 					<xsd:element name="identificativoPSP" type="ppt:stText35" />
-					<xsd:element name="identificativoIntermediarioPSP" type="ppt:stText35" minOccurs="0" />
-					<xsd:element name="identificativoCanale" type="ppt:stText35" minOccurs="0" />
+					<xsd:element name="identificativoIntermediarioPSP" type="ppt:stText35" />
+					<xsd:element name="identificativoCanale" type="ppt:stText35" />
 					<xsd:element name="password" type="ppt:stPassword" />
 					<xsd:element name="identificativoDominio" type="ppt:stText35" />
 					<xsd:element name="identificativoFlusso" type="xsd:string" />
@@ -232,7 +235,7 @@
 				<xsd:complexContent>
 					<xsd:extension base="ppt:risposta">
 						<xsd:sequence>
-							<xsd:element name="esito" type="xsd:string" minOccurs="0" />
+							<xsd:element name="esito" type="xsd:string" minOccurs="1" />
 						</xsd:sequence>
 					</xsd:extension>
 				</xsd:complexContent>
@@ -240,7 +243,7 @@
 
 			<xsd:complexType name="nodoChiediInformativaPA">
 				<xsd:sequence>
-					<xsd:element name="identificativoPSP" type="ppt:stText35" minOccurs="0" />
+					<xsd:element name="identificativoPSP" type="ppt:stText35" />
 					<xsd:element name="identificativoIntermediarioPSP" type="ppt:stText35" />
 					<xsd:element name="identificativoCanale" type="ppt:stText35" />
 					<xsd:element name="password" type="ppt:stPassword" />
@@ -333,7 +336,7 @@
 					<xsd:element name="identificativoDominio" type="ppt:stText35" />
 					<xsd:element name="identificativoUnivocoVersamento" type="ppt:stText35" />
 					<xsd:element name="codiceContestoPagamento" type="ppt:stText35" />
-					<xsd:element name="er" type="xsd:base64Binary" minOccurs="0"  xmime:expectedContentTypes="application/octet-stream" xmlns:xmime="http://www.w3.org/2005/05/xmlmime" />
+					<xsd:element name="er" type="xsd:base64Binary" xmime:expectedContentTypes="application/octet-stream" xmlns:xmime="http://www.w3.org/2005/05/xmlmime" />
 				</xsd:sequence>
 			</xsd:complexType>
 						
@@ -341,7 +344,7 @@
 				<xsd:complexContent>
 					<xsd:extension base="ppt:risposta">
 						<xsd:sequence>
-							<xsd:element name="esito" type="xsd:string" minOccurs="0" />
+							<xsd:element name="esito" type="xsd:string" minOccurs="1" />
 						</xsd:sequence>
 					</xsd:extension>
 				</xsd:complexContent>
@@ -364,7 +367,7 @@
 				<xsd:complexContent>
 					<xsd:extension base="ppt:risposta">
 						<xsd:sequence>
-							<xsd:element name="esito" type="xsd:string" minOccurs="0" />
+							<xsd:element name="esito" type="xsd:string" minOccurs="1" />
 						</xsd:sequence>
 					</xsd:extension>
 				</xsd:complexContent>


### PR DESCRIPTION
`nodoVerificaRPTReponse` and `nodoAttivaRPTResponse` can contains faultBean originated by PA ( `originalFaultCode`).

Note: to receive `originalFaultbeanCode` it is necessary to configure pagoPA