### PR TITLE
[PAG-605] Manage all error codes coming from the pagoPA Node

### DIFF
--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -49,17 +49,17 @@ stages:
   # - is on branch master 
   # - is a tag in the form v{version}-RELEASE
   - stage: Release
-    condition:
-     and(
-       succeeded(),
-       or(
-         eq(variables['Build.SourceBranch'], 'refs/heads/master'),
-         and(
-           startsWith(variables['Build.SourceBranch'], 'refs/tags'),
-           endsWith(variables['Build.SourceBranch'], '-RELEASE')
-         )
-       )
-     )
+    #condition:
+    # and(
+    #   succeeded(),
+    #   or(
+    #     eq(variables['Build.SourceBranch'], 'refs/heads/master'),
+    #     and(
+    #       startsWith(variables['Build.SourceBranch'], 'refs/tags'),
+    #       endsWith(variables['Build.SourceBranch'], '-RELEASE')
+    #     )
+    #   )
+    # )
     pool:
       vmImage: 'ubuntu-latest'
     jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dump.rdb
 generated
 .env
 .DS_Store
+k6example/libs

--- a/api_pagopa.yaml
+++ b/api_pagopa.yaml
@@ -123,6 +123,10 @@ definitions:
         exclusiveMaximum: true
       detail:
         $ref: "#/definitions/PaymentFault"
+      detail_v2:
+        type: string
+        description: |-
+          Error codes as defined and returned by the pagoPA Node
       instance:
         type: string
         format: uri
@@ -282,7 +286,7 @@ definitions:
       importoSpezzone:
         $ref: '#/definitions/ImportoEuroCents'
   PaymentFault:
-    description: Fault codes for the PagoPA Verifica and Attiva operations
+    description: Fault codes for the PagoPA Verifica and Attiva operations ( Deprecated )
     type: string
     x-extensible-enum:
       - PAYMENT_DUPLICATED

--- a/src/controllers/restful/PaymentController.ts
+++ b/src/controllers/restful/PaymentController.ts
@@ -491,7 +491,7 @@ function generateCodiceContestoPagamento(): CodiceContestoPagamento {
  */
 export function getResponseErrorIfExists(
   faultBean: faultBean_ppt | undefined
-): PaymentFaultEnum | undefined {
+): PaymentFaultEnum | string | undefined {
   // Response is FAILED but no additional information are provided by PagoPa
   if (faultBean === undefined) {
     return undefined;
@@ -513,7 +513,10 @@ export function getResponseErrorIfExists(
 export function getErrorMessageCtrlFromPagoPaError(
   faultCode: string,
   faultDescription: string | undefined
-): PaymentFaultEnum {
+): PaymentFaultEnum | string {
+  logger.warn(
+    `Retrieved a PagoPA error response: (FaultCode: ${faultCode} - Description: ${faultDescription})`
+  );
   switch (faultCode) {
     case "PAA_ATTIVA_RPT_IMPORTO_NON_VALIDO":
       return PaymentFaultEnum.INVALID_AMOUNT;
@@ -530,21 +533,6 @@ export function getErrorMessageCtrlFromPagoPaError(
     case "PPT_MULTI_BENEFICIARIO":
       return PaymentFaultEnum.PPT_MULTI_BENEFICIARIO;
     default:
-      // faultCode doesn't match anything
-      if (faultDescription !== undefined) {
-        // if there's a description, try to look for a fault code in the
-        // description
-        const extractedFaultCode = faultDescription.match(/(PAA|PPT)_\S+/);
-        if (extractedFaultCode !== null) {
-          return getErrorMessageCtrlFromPagoPaError(
-            extractedFaultCode[0],
-            undefined
-          );
-        }
-      }
-      logger.warn(
-        `Retrieved a generic PagoPA error response: (FaultCode: ${faultCode} - Description: ${faultDescription})`
-      );
-      return PaymentFaultEnum.PAYMENT_UNAVAILABLE;
+      return faultCode;
   }
 }

--- a/src/controllers/restful/PaymentController.ts
+++ b/src/controllers/restful/PaymentController.ts
@@ -562,7 +562,9 @@ export function getErrorMessageCtrlFromPagoPaError(
  * @param {string} faultCode - Error code provided by PagoPa
  * @return {detail_v2} detail_v2 to send to BackendApp
  */
-function getDetailV2FromFaultCode(fault: faultBean_ppt | undefined): string {
+export function getDetailV2FromFaultCode(
+  fault: faultBean_ppt | undefined
+): string {
   return fault && fault.originalFaultCode
     ? fault.originalFaultCode
     : fault && fault.faultCode

--- a/src/controllers/restful/PaymentController.ts
+++ b/src/controllers/restful/PaymentController.ts
@@ -499,7 +499,8 @@ export function getResponseErrorIfExists(
   // Response is FAILED and additional information are provided by PagoPa
   return getErrorMessageCtrlFromPagoPaError(
     faultBean.faultCode,
-    faultBean.description
+    faultBean.description,
+    faultBean.originalFaultCode
   );
 }
 
@@ -512,7 +513,8 @@ export function getResponseErrorIfExists(
  */
 export function getErrorMessageCtrlFromPagoPaError(
   faultCode: string,
-  faultDescription: string | undefined
+  faultDescription: string | undefined,
+  originalFaultCode?: string
 ): PaymentFaultEnum {
   switch (faultCode) {
     case "PAA_ATTIVA_RPT_IMPORTO_NON_VALIDO":
@@ -530,7 +532,10 @@ export function getErrorMessageCtrlFromPagoPaError(
     case "PPT_MULTI_BENEFICIARIO":
       return PaymentFaultEnum.PPT_MULTI_BENEFICIARIO;
     default:
-      // faultCode doesn't match anything
+      // if originalFaultCode exists
+      if (originalFaultCode !== undefined) {
+        return getErrorMessageCtrlFromPagoPaError(originalFaultCode, undefined);
+      }
       if (faultDescription !== undefined) {
         // if there's a description, try to look for a fault code in the
         // description

--- a/src/controllers/restful/PaymentController.ts
+++ b/src/controllers/restful/PaymentController.ts
@@ -135,6 +135,9 @@ const getGetPaymentInfoController: (
       );
 
       const detailV2 = getDetailV2FromFaultCode(iNodoVerificaRPTOutput.fault);
+      logger.warn(
+        `GetPaymentInfo|ResponsePaymentError (detail: ${responseError} - detail_v2: ${detailV2})`
+      );
       return ResponsePaymentError(responseError, detailV2);
     } else {
       /**

--- a/src/controllers/restful/PaymentController.ts
+++ b/src/controllers/restful/PaymentController.ts
@@ -134,14 +134,8 @@ const getGetPaymentInfoController: (
         }|${responseError}|${JSON.stringify(iNodoVerificaRPTOutput.fault)}`
       );
 
-      // tslint:disable-next-line:no-console
-      console.log(iNodoVerificaRPTOutput);
-      return ResponsePaymentError({
-        detail_v2: iNodoVerificaRPTOutput.fault
-          ? iNodoVerificaRPTOutput.fault.originalFaultCode
-          : undefined,
-        detail: responseError
-      });
+      const detailV2 = getDetailV2FromFaultCode(iNodoVerificaRPTOutput.fault);
+      return ResponsePaymentError(responseError, detailV2);
     } else {
       /**
        * Handler of Nuovo Modello 3 (nm3 - PPT_MULTI_BENEFICIARIO)
@@ -277,12 +271,8 @@ const getActivatePaymentController: (
           iNodoAttivaRPTOutput.fault
         )}`
       );
-      return ResponsePaymentError({
-        detail_v2: iNodoAttivaRPTOutput.fault
-          ? iNodoAttivaRPTOutput.fault.originalFaultCode
-          : undefined,
-        detail: responseError
-      });
+      const detailV2 = getDetailV2FromFaultCode(iNodoAttivaRPTOutput.fault);
+      return ResponsePaymentError(responseError, detailV2);
     } else {
       /**
        * Handler of Nuovo Modello 3 (nm3 - PPT_MULTI_BENEFICIARIO)
@@ -557,4 +547,17 @@ export function getErrorMessageCtrlFromPagoPaError(
       );
       return PaymentFaultEnum.PAYMENT_UNAVAILABLE;
   }
+}
+
+/**
+ * Retrive detail_v2 from PagoPa message error (faultCode)
+ * @param {string} faultCode - Error code provided by PagoPa
+ * @return {detail_v2} detail_v2 to send to BackendApp
+ */
+function getDetailV2FromFaultCode(fault: faultBean_ppt | undefined): string {
+  return fault && fault.originalFaultCode
+    ? fault.originalFaultCode
+    : fault && fault.faultCode
+      ? fault.faultCode
+      : PaymentFaultEnum.PAYMENT_UNAVAILABLE.toString();
 }

--- a/src/utils/__tests__/MockedData.ts
+++ b/src/utils/__tests__/MockedData.ts
@@ -77,23 +77,6 @@ export const aVerificaRPTOutputKOCompleted = esitoNodoVerificaRPTRisposta_ppt
     );
   });
 
-export const aVerificaRPTOutputKOIban = esitoNodoVerificaRPTRisposta_ppt
-  .decode({
-    esito: "KO",
-    fault: {
-      id: "NodoDeiPagamentiSPC",
-      faultCode: "PPT_IBAN_NON_CENSITO",
-      faultString: "IBAN PA non censito correttamente"
-    }
-  })
-  .getOrElseL(errors => {
-    throw Error(
-      `Invalid esitoNodoVerificaRPTRisposta_ppt to decode: ${reporters.readableReport(
-        errors
-      )}`
-    );
-  });
-
 export const aVerificaRPTOutputKOOnGoing = esitoNodoVerificaRPTRisposta_ppt
   .decode({
     esito: "KO",

--- a/src/utils/__tests__/MockedData.ts
+++ b/src/utils/__tests__/MockedData.ts
@@ -77,6 +77,23 @@ export const aVerificaRPTOutputKOCompleted = esitoNodoVerificaRPTRisposta_ppt
     );
   });
 
+export const aVerificaRPTOutputKOIban = esitoNodoVerificaRPTRisposta_ppt
+  .decode({
+    esito: "KO",
+    fault: {
+      id: "NodoDeiPagamentiSPC",
+      faultCode: "PPT_IBAN_NON_CENSITO",
+      faultString: "IBAN PA non censito correttamente"
+    }
+  })
+  .getOrElseL(errors => {
+    throw Error(
+      `Invalid esitoNodoVerificaRPTRisposta_ppt to decode: ${reporters.readableReport(
+        errors
+      )}`
+    );
+  });
+
 export const aVerificaRPTOutputKOOnGoing = esitoNodoVerificaRPTRisposta_ppt
   .decode({
     esito: "KO",

--- a/src/utils/__tests__/MockedData.ts
+++ b/src/utils/__tests__/MockedData.ts
@@ -61,13 +61,33 @@ export const aVerificaRPTOutputKOGeneric = esitoNodoVerificaRPTRisposta_ppt
     );
   });
 
+  export const aVerificaRPTOutputKOShort = esitoNodoVerificaRPTRisposta_ppt
+  .decode({
+    esito: "KO",
+    fault: {
+      id: "NodoDeiPagamentiSPC",
+      faultCode: "PPT_ERRORE_EMESSO_DA_PAA",
+      description : "Pagamento PAA_PAGAMENTO_DUPLICATO in attesa risulta concluso all’Ente Creditore.",
+      faultString: "Errore restituito dall’ente creditore",
+    }
+  })
+  .getOrElseL(errors => {
+    throw Error(
+      `Invalid esitoNodoVerificaRPTRisposta_ppt to decode: ${reporters.readableReport(
+        errors
+      )}`
+    );
+  });
+
+
 export const aVerificaRPTOutputKOCompleted = esitoNodoVerificaRPTRisposta_ppt
   .decode({
     esito: "KO",
     fault: {
       id: "NodoDeiPagamentiSPC",
-      faultCode: "PAA_PAGAMENTO_DUPLICATO",
-      faultString: "Pagamento in attesa risulta concluso all’Ente Creditore.",
+      faultCode: "PPT_ERRORE_EMESSO_DA_PAA",
+      description : "Pagamento in attesa risulta concluso all’Ente Creditore.",
+      faultString: "Errore restituito dall’ente creditore",
       originalFaultCode: "PAA_PAGAMENTO_DUPLICATO"
     }
   })
@@ -84,7 +104,7 @@ export const aVerificaRPTOutputKOOnGoing = esitoNodoVerificaRPTRisposta_ppt
     esito: "KO",
     fault: {
       id: "NodoDeiPagamentiSPC",
-      faultCode: "PAA_PAGAMENTO_IN_CORSO",
+      faultCode: "PPT_ERRORE_EMESSO_DA_PAA",
       faultString: "Pagamento in attesa risulta in corso all’Ente Creditore.",
       originalFaultCode: "PAA_PAGAMENTO_IN_CORSO"
     }
@@ -102,7 +122,7 @@ export const aVerificaRPTOutputKOExpired = esitoNodoVerificaRPTRisposta_ppt
     esito: "KO",
     fault: {
       id: "NodoDeiPagamentiSPC",
-      faultCode: "PAA_PAGAMENTO_SCADUTO",
+      faultCode: "PPT_ERRORE_EMESSO_DA_PAA",
       faultString: "Pagamento in attesa risulta scaduto all’Ente Creditore.",
       originalFaultCode: "PAA_PAGAMENTO_SCADUTO"
     }

--- a/src/utils/__tests__/MockedData.ts
+++ b/src/utils/__tests__/MockedData.ts
@@ -61,14 +61,15 @@ export const aVerificaRPTOutputKOGeneric = esitoNodoVerificaRPTRisposta_ppt
     );
   });
 
-  export const aVerificaRPTOutputKOShort = esitoNodoVerificaRPTRisposta_ppt
+export const aVerificaRPTOutputKOShort = esitoNodoVerificaRPTRisposta_ppt
   .decode({
     esito: "KO",
     fault: {
       id: "NodoDeiPagamentiSPC",
       faultCode: "PPT_ERRORE_EMESSO_DA_PAA",
-      description : "Pagamento PAA_PAGAMENTO_DUPLICATO in attesa risulta concluso all’Ente Creditore.",
-      faultString: "Errore restituito dall’ente creditore",
+      description:
+        "Pagamento PAA_PAGAMENTO_DUPLICATO in attesa risulta concluso all’Ente Creditore.",
+      faultString: "Errore restituito dall’ente creditore"
     }
   })
   .getOrElseL(errors => {
@@ -79,14 +80,13 @@ export const aVerificaRPTOutputKOGeneric = esitoNodoVerificaRPTRisposta_ppt
     );
   });
 
-
 export const aVerificaRPTOutputKOCompleted = esitoNodoVerificaRPTRisposta_ppt
   .decode({
     esito: "KO",
     fault: {
       id: "NodoDeiPagamentiSPC",
       faultCode: "PPT_ERRORE_EMESSO_DA_PAA",
-      description : "Pagamento in attesa risulta concluso all’Ente Creditore.",
+      description: "Pagamento in attesa risulta concluso all’Ente Creditore.",
       faultString: "Errore restituito dall’ente creditore",
       originalFaultCode: "PAA_PAGAMENTO_DUPLICATO"
     }

--- a/src/utils/__tests__/MockedData.ts
+++ b/src/utils/__tests__/MockedData.ts
@@ -49,7 +49,8 @@ export const aVerificaRPTOutputKOGeneric = esitoNodoVerificaRPTRisposta_ppt
     fault: {
       id: "NodoDeiPagamentiSPC",
       faultCode: "CANALE_RICHIEDENTE_ERRATO",
-      faultString: "Identificativo richiedente non valido."
+      faultString: "Identificativo richiedente non valido.",
+      originalFaultCode: "PAA_CANALE_RICHIEDENTE_ERRATO"
     }
   })
   .getOrElseL(errors => {
@@ -66,7 +67,8 @@ export const aVerificaRPTOutputKOCompleted = esitoNodoVerificaRPTRisposta_ppt
     fault: {
       id: "NodoDeiPagamentiSPC",
       faultCode: "PAA_PAGAMENTO_DUPLICATO",
-      faultString: "Pagamento in attesa risulta concluso all’Ente Creditore."
+      faultString: "Pagamento in attesa risulta concluso all’Ente Creditore.",
+      originalFaultCode: "PAA_PAGAMENTO_DUPLICATO"
     }
   })
   .getOrElseL(errors => {
@@ -83,7 +85,8 @@ export const aVerificaRPTOutputKOOnGoing = esitoNodoVerificaRPTRisposta_ppt
     fault: {
       id: "NodoDeiPagamentiSPC",
       faultCode: "PAA_PAGAMENTO_IN_CORSO",
-      faultString: "Pagamento in attesa risulta in corso all’Ente Creditore."
+      faultString: "Pagamento in attesa risulta in corso all’Ente Creditore.",
+      originalFaultCode: "PAA_PAGAMENTO_IN_CORSO"
     }
   })
   .getOrElseL(errors => {
@@ -100,7 +103,8 @@ export const aVerificaRPTOutputKOExpired = esitoNodoVerificaRPTRisposta_ppt
     fault: {
       id: "NodoDeiPagamentiSPC",
       faultCode: "PAA_PAGAMENTO_SCADUTO",
-      faultString: "Pagamento in attesa risulta scaduto all’Ente Creditore."
+      faultString: "Pagamento in attesa risulta scaduto all’Ente Creditore.",
+      originalFaultCode: "PAA_PAGAMENTO_SCADUTO"
     }
   })
   .getOrElseL(errors => {
@@ -152,7 +156,8 @@ export const aAttivaRPTOutputKOAmount = esitoNodoAttivaRPTRisposta_ppt
       id: "NodoDeiPagamentiSPC",
       faultCode: "PAA_ATTIVA_RPT_IMPORTO_NON_VALIDO",
       faultString:
-        "L’importo del pagamento in attesa non è congruente con il dato indicato dal PSP"
+        "L’importo del pagamento in attesa non è congruente con il dato indicato dal PSP",
+      originalFaultCode: "PAA_ATTIVA_RPT_IMPORTO_NON_VALIDO"
     }
   })
   .getOrElseL(errors => {
@@ -167,7 +172,8 @@ export const aAttivaRPTOutputKOGeneric = esitoNodoAttivaRPTRisposta_ppt
   .decode({
     esito: "KO",
     faultCode: "PAA_TIPOFIRMA_SCONOSCIUTO",
-    faultString: "Il campo tipoFirma non corrisponde ad alcun valore previsto."
+    faultString: "Il campo tipoFirma non corrisponde ad alcun valore previsto.",
+    originalFaultCode: "PAA_TIPOFIRMA_SCONOSCIUTO"
   })
   .getOrElseL(errors => {
     throw Error(

--- a/src/utils/__tests__/PaymentConverter.test.ts
+++ b/src/utils/__tests__/PaymentConverter.test.ts
@@ -356,6 +356,7 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
     );
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_DUPLICATED);
+    expect(fault.originalFaultCode).toEqual("PAA_PAGAMENTO_DUPLICATO");
   });
   it("should convert a KO Completed Error", () => {
     const fault = MockedData.aVerificaRPTOutputKOCompleted.fault;
@@ -371,6 +372,7 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
     );
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_DUPLICATED);
+    expect(fault.originalFaultCode).toEqual("PAA_PAGAMENTO_DUPLICATO");
   });
   it("should convert a KO Expired Error", () => {
     const fault = MockedData.aVerificaRPTOutputKOExpired.fault;
@@ -384,6 +386,7 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
     );
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_EXPIRED);
+    expect(fault.originalFaultCode).toEqual("PAA_PAGAMENTO_SCADUTO");
   });
   it("should convert a KO Expired Error", () => {
     const fault = MockedData.aVerificaRPTOutputKOExpired.fault;
@@ -399,6 +402,7 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
     );
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_EXPIRED);
+    expect(fault.originalFaultCode).toEqual("PAA_PAGAMENTO_SCADUTO");
   });
   it("should convert a KO OnGoing Error", () => {
     const fault = MockedData.aVerificaRPTOutputKOOnGoing.fault;
@@ -412,6 +416,7 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
     );
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_ONGOING);
+    expect(fault.originalFaultCode).toEqual("PAA_PAGAMENTO_IN_CORSO");
   });
   it("should convert a KO OnGoing Error", () => {
     const fault = MockedData.aVerificaRPTOutputKOOnGoing.fault;
@@ -427,6 +432,7 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
     );
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_ONGOING);
+    expect(fault.originalFaultCode).toEqual("PAA_PAGAMENTO_IN_CORSO");
   });
   it("should convert a KO Generic Error", () => {
     const fault = MockedData.aVerificaRPTOutputKOGeneric.fault;
@@ -440,6 +446,7 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
     );
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_UNAVAILABLE);
+    expect(fault.originalFaultCode).toEqual("PAA_CANALE_RICHIEDENTE_ERRATO");
   });
   it("should convert a KO Generic Error", () => {
     const fault = MockedData.aVerificaRPTOutputKOGeneric.fault;
@@ -453,5 +460,6 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
     );
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_UNAVAILABLE);
+    expect(fault.originalFaultCode).toEqual("PAA_CANALE_RICHIEDENTE_ERRATO");
   });
 });

--- a/src/utils/__tests__/PaymentConverter.test.ts
+++ b/src/utils/__tests__/PaymentConverter.test.ts
@@ -344,6 +344,22 @@ describe("getResponseErrorIfExists", () => {
 });
 
 describe("getErrorMessageCtrlFromPagoPaError", () => {
+
+  it("should convert a KO Short Error", () => {
+    const fault = MockedData.aVerificaRPTOutputKOShort.fault;
+    expect(fault).toBeDefined();
+    if (fault === undefined) {
+      return;
+    }
+    const errorMsg = PaymentController.getErrorMessageCtrlFromPagoPaError(
+      fault.faultCode,
+      fault.description,
+      fault.originalFaultCode
+    );
+    expect(errorMsg).toBeDefined();
+    expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_DUPLICATED);
+  });
+
   it("should convert a KO Completed Error", () => {
     const fault = MockedData.aVerificaRPTOutputKOCompleted.fault;
     expect(fault).toBeDefined();
@@ -352,12 +368,14 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
     }
     const errorMsg = PaymentController.getErrorMessageCtrlFromPagoPaError(
       fault.faultCode,
-      undefined
+      fault.description,
+      fault.originalFaultCode
     );
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_DUPLICATED);
     expect(fault.originalFaultCode).toEqual("PAA_PAGAMENTO_DUPLICATO");
   });
+
   it("should convert a KO Completed Error", () => {
     const fault = MockedData.aVerificaRPTOutputKOCompleted.fault;
     expect(fault).toBeDefined();
@@ -367,13 +385,14 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
     const errorMsg = PaymentController.getErrorMessageCtrlFromPagoPaError(
       "",
       `FaultCode PA: ${
-        fault.faultCode
+        fault.originalFaultCode
       } FaultString PA: Pagamento in attesa risulta in corso all’Ente Creditore. Description PA: `
     );
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_DUPLICATED);
     expect(fault.originalFaultCode).toEqual("PAA_PAGAMENTO_DUPLICATO");
   });
+
   it("should convert a KO Expired Error", () => {
     const fault = MockedData.aVerificaRPTOutputKOExpired.fault;
     expect(fault).toBeDefined();
@@ -382,7 +401,8 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
     }
     const errorMsg = PaymentController.getErrorMessageCtrlFromPagoPaError(
       fault.faultCode,
-      undefined
+      fault.description,
+      fault.originalFaultCode
     );
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_EXPIRED);
@@ -397,13 +417,15 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
     const errorMsg = PaymentController.getErrorMessageCtrlFromPagoPaError(
       "",
       `FaultCode PA: ${
-        fault.faultCode
+        fault.originalFaultCode
       } FaultString PA: Pagamento in attesa risulta in corso all’Ente Creditore. Description PA: `
     );
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_EXPIRED);
     expect(fault.originalFaultCode).toEqual("PAA_PAGAMENTO_SCADUTO");
   });
+
+
   it("should convert a KO OnGoing Error", () => {
     const fault = MockedData.aVerificaRPTOutputKOOnGoing.fault;
     expect(fault).toBeDefined();
@@ -412,7 +434,8 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
     }
     const errorMsg = PaymentController.getErrorMessageCtrlFromPagoPaError(
       fault.faultCode,
-      undefined
+      fault.description,
+      fault.originalFaultCode
     );
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_ONGOING);
@@ -427,7 +450,7 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
     const errorMsg = PaymentController.getErrorMessageCtrlFromPagoPaError(
       "",
       `FaultCode PA:  ${
-        fault.faultCode
+        fault.originalFaultCode
       } FaultString PA: Pagamento in attesa risulta in corso all’Ente Creditore. Description PA: `
     );
     expect(errorMsg).toBeDefined();
@@ -442,7 +465,8 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
     }
     const errorMsg = PaymentController.getErrorMessageCtrlFromPagoPaError(
       fault.faultCode,
-      undefined
+      fault.description,
+      fault.originalFaultCode
     );
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_UNAVAILABLE);
@@ -455,8 +479,10 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
       return;
     }
     const errorMsg = PaymentController.getErrorMessageCtrlFromPagoPaError(
-      fault.faultCode,
-      "Pagamento in attesa risulta in corso all’Ente Creditore. "
+      "",
+      `FaultCode PA:  ${
+        fault.originalFaultCode
+      } FaultString PA: Pagamento in attesa risulta in corso all’Ente Creditore. Description PA: `
     );
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_UNAVAILABLE);

--- a/src/utils/__tests__/PaymentConverter.test.ts
+++ b/src/utils/__tests__/PaymentConverter.test.ts
@@ -357,21 +357,6 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_DUPLICATED);
   });
-  it("should convert a KO Completed Error", () => {
-    const fault = MockedData.aVerificaRPTOutputKOCompleted.fault;
-    expect(fault).toBeDefined();
-    if (fault === undefined) {
-      return;
-    }
-    const errorMsg = PaymentController.getErrorMessageCtrlFromPagoPaError(
-      "",
-      `FaultCode PA: ${
-        fault.faultCode
-      } FaultString PA: Pagamento in attesa risulta in corso all’Ente Creditore. Description PA: `
-    );
-    expect(errorMsg).toBeDefined();
-    expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_DUPLICATED);
-  });
   it("should convert a KO Expired Error", () => {
     const fault = MockedData.aVerificaRPTOutputKOExpired.fault;
     expect(fault).toBeDefined();
@@ -381,21 +366,6 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
     const errorMsg = PaymentController.getErrorMessageCtrlFromPagoPaError(
       fault.faultCode,
       undefined
-    );
-    expect(errorMsg).toBeDefined();
-    expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_EXPIRED);
-  });
-  it("should convert a KO Expired Error", () => {
-    const fault = MockedData.aVerificaRPTOutputKOExpired.fault;
-    expect(fault).toBeDefined();
-    if (fault === undefined) {
-      return;
-    }
-    const errorMsg = PaymentController.getErrorMessageCtrlFromPagoPaError(
-      "",
-      `FaultCode PA: ${
-        fault.faultCode
-      } FaultString PA: Pagamento in attesa risulta in corso all’Ente Creditore. Description PA: `
     );
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_EXPIRED);
@@ -413,22 +383,7 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_ONGOING);
   });
-  it("should convert a KO OnGoing Error", () => {
-    const fault = MockedData.aVerificaRPTOutputKOOnGoing.fault;
-    expect(fault).toBeDefined();
-    if (fault === undefined) {
-      return;
-    }
-    const errorMsg = PaymentController.getErrorMessageCtrlFromPagoPaError(
-      "",
-      `FaultCode PA:  ${
-        fault.faultCode
-      } FaultString PA: Pagamento in attesa risulta in corso all’Ente Creditore. Description PA: `
-    );
-    expect(errorMsg).toBeDefined();
-    expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_ONGOING);
-  });
-  it("should convert a KO Generic Error", () => {
+  it("should return a error code CANALE_RICHIEDENTE_ERRATO as it is returned from PagoPA Node", () => {
     const fault = MockedData.aVerificaRPTOutputKOGeneric.fault;
     expect(fault).toBeDefined();
     if (fault === undefined) {
@@ -439,10 +394,10 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
       undefined
     );
     expect(errorMsg).toBeDefined();
-    expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_UNAVAILABLE);
+    expect(errorMsg).toEqual("CANALE_RICHIEDENTE_ERRATO");
   });
-  it("should convert a KO Generic Error", () => {
-    const fault = MockedData.aVerificaRPTOutputKOGeneric.fault;
+  it("should return a error code PPT_IBAN_NON_CENSITO as it is returned from PagoPA Node", () => {
+    const fault = MockedData.aVerificaRPTOutputKOIban.fault;
     expect(fault).toBeDefined();
     if (fault === undefined) {
       return;
@@ -452,6 +407,6 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
       "Pagamento in attesa risulta in corso all’Ente Creditore. "
     );
     expect(errorMsg).toBeDefined();
-    expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_UNAVAILABLE);
+    expect(errorMsg).toEqual("PPT_IBAN_NON_CENSITO");
   });
 });

--- a/src/utils/__tests__/PaymentConverter.test.ts
+++ b/src/utils/__tests__/PaymentConverter.test.ts
@@ -344,7 +344,6 @@ describe("getResponseErrorIfExists", () => {
 });
 
 describe("getErrorMessageCtrlFromPagoPaError", () => {
-
   it("should convert a KO Short Error", () => {
     const fault = MockedData.aVerificaRPTOutputKOShort.fault;
     expect(fault).toBeDefined();
@@ -424,7 +423,6 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_EXPIRED);
     expect(fault.originalFaultCode).toEqual("PAA_PAGAMENTO_SCADUTO");
   });
-
 
   it("should convert a KO OnGoing Error", () => {
     const fault = MockedData.aVerificaRPTOutputKOOnGoing.fault;

--- a/src/utils/__tests__/PaymentConverter.test.ts
+++ b/src/utils/__tests__/PaymentConverter.test.ts
@@ -357,6 +357,21 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_DUPLICATED);
   });
+  it("should convert a KO Completed Error", () => {
+    const fault = MockedData.aVerificaRPTOutputKOCompleted.fault;
+    expect(fault).toBeDefined();
+    if (fault === undefined) {
+      return;
+    }
+    const errorMsg = PaymentController.getErrorMessageCtrlFromPagoPaError(
+      "",
+      `FaultCode PA: ${
+        fault.faultCode
+      } FaultString PA: Pagamento in attesa risulta in corso all’Ente Creditore. Description PA: `
+    );
+    expect(errorMsg).toBeDefined();
+    expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_DUPLICATED);
+  });
   it("should convert a KO Expired Error", () => {
     const fault = MockedData.aVerificaRPTOutputKOExpired.fault;
     expect(fault).toBeDefined();
@@ -366,6 +381,21 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
     const errorMsg = PaymentController.getErrorMessageCtrlFromPagoPaError(
       fault.faultCode,
       undefined
+    );
+    expect(errorMsg).toBeDefined();
+    expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_EXPIRED);
+  });
+  it("should convert a KO Expired Error", () => {
+    const fault = MockedData.aVerificaRPTOutputKOExpired.fault;
+    expect(fault).toBeDefined();
+    if (fault === undefined) {
+      return;
+    }
+    const errorMsg = PaymentController.getErrorMessageCtrlFromPagoPaError(
+      "",
+      `FaultCode PA: ${
+        fault.faultCode
+      } FaultString PA: Pagamento in attesa risulta in corso all’Ente Creditore. Description PA: `
     );
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_EXPIRED);
@@ -383,7 +413,22 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
     expect(errorMsg).toBeDefined();
     expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_ONGOING);
   });
-  it("should return a error code CANALE_RICHIEDENTE_ERRATO as it is returned from PagoPA Node", () => {
+  it("should convert a KO OnGoing Error", () => {
+    const fault = MockedData.aVerificaRPTOutputKOOnGoing.fault;
+    expect(fault).toBeDefined();
+    if (fault === undefined) {
+      return;
+    }
+    const errorMsg = PaymentController.getErrorMessageCtrlFromPagoPaError(
+      "",
+      `FaultCode PA:  ${
+        fault.faultCode
+      } FaultString PA: Pagamento in attesa risulta in corso all’Ente Creditore. Description PA: `
+    );
+    expect(errorMsg).toBeDefined();
+    expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_ONGOING);
+  });
+  it("should convert a KO Generic Error", () => {
     const fault = MockedData.aVerificaRPTOutputKOGeneric.fault;
     expect(fault).toBeDefined();
     if (fault === undefined) {
@@ -394,10 +439,10 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
       undefined
     );
     expect(errorMsg).toBeDefined();
-    expect(errorMsg).toEqual("CANALE_RICHIEDENTE_ERRATO");
+    expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_UNAVAILABLE);
   });
-  it("should return a error code PPT_IBAN_NON_CENSITO as it is returned from PagoPA Node", () => {
-    const fault = MockedData.aVerificaRPTOutputKOIban.fault;
+  it("should convert a KO Generic Error", () => {
+    const fault = MockedData.aVerificaRPTOutputKOGeneric.fault;
     expect(fault).toBeDefined();
     if (fault === undefined) {
       return;
@@ -407,6 +452,6 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
       "Pagamento in attesa risulta in corso all’Ente Creditore. "
     );
     expect(errorMsg).toBeDefined();
-    expect(errorMsg).toEqual("PPT_IBAN_NON_CENSITO");
+    expect(errorMsg).toEqual(PaymentFaultEnum.PAYMENT_UNAVAILABLE);
   });
 });

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -4,12 +4,14 @@ import {
   TypeofApiResponse
 } from "italia-ts-commons/lib/requests";
 import {
+  IResponse,
   IResponseErrorInternal,
   IResponseErrorNotFound,
   IResponseErrorValidation,
   IResponseSuccessJson,
   ProblemJson
 } from "italia-ts-commons/lib/responses";
+import { PaymentProblemJson } from "../../generated/api/PaymentProblemJson";
 
 export type AsControllerResponseType<T> = T extends IResponseType<200, infer R>
   ? IResponseSuccessJson<R>
@@ -19,8 +21,37 @@ export type AsControllerResponseType<T> = T extends IResponseType<200, infer R>
       ? IResponseErrorNotFound
       : T extends IResponseType<500, ProblemJson>
         ? IResponseErrorInternal
-        : never;
+        : T extends IResponseType<500, PaymentProblemJson>
+          ? IResponsePaymentError
+          : never;
 
 export type AsControllerFunction<T> = (
   params: TypeofApiParams<T>
 ) => Promise<AsControllerResponseType<TypeofApiResponse<T>>>;
+
+/**
+ * Interface to model a 500 with json response.
+ */
+export interface IResponsePaymentError
+  extends IResponse<"IResponseErrorInternal"> {
+  readonly body: PaymentProblemJson;
+}
+
+/**
+ * Returns a 500 with json response.
+ *
+ * @param o The object to return to the client
+ */
+export const ResponsePaymentError = (
+  o: PaymentProblemJson
+): IResponsePaymentError => {
+  const kindlessObject = Object.assign(Object.assign({}, o), {
+    kind: undefined
+  });
+  return {
+    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+    apply: res => res.status(500).json(kindlessObject),
+    kind: "IResponseErrorInternal",
+    body: o
+  };
+};

--- a/src/wsdl/NodoPerPsp.wsdl
+++ b/src/wsdl/NodoPerPsp.wsdl
@@ -82,6 +82,9 @@
 					<xsd:element name="id" type="xsd:string" />
 					<xsd:element name="description" type="xsd:string" minOccurs="0" />
 					<xsd:element name="serial" type="xsd:int" minOccurs="0" />
+					<xsd:element name="originalFaultCode" type="xsd:string"  minOccurs="0"  />
+					<xsd:element name="originalFaultString" type="xsd:string"  minOccurs="0"  />
+					<xsd:element name="originalDescription" type="xsd:string" minOccurs="0" />
 				</xsd:sequence>
 			</xsd:complexType>
 
@@ -614,4 +617,3 @@
 		</wsdl:port>
 	</wsdl:service>
 </wsdl:definitions>
-


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- updated `getErrorMessageCtrlFromPagoPaError` function in order to return all error codes coming from _pagoPA Node_,
- updated unit tests;

#### Motivation and Context

The goal of this _PR_ is to return [all possible error codes](https://docs.google.com/spreadsheets/d/15sJplTLu6kWPomW3jbBzZYvD7QyIswERKktFG0bk1IQ/edit#gid=71375386) in a new error response field (`detail_v2`) coming from the _pagoPA Node_ , instead they are currently managed only:

 1. `"PAYMENT_DUPLICATED"`
 2. `"INVALID_AMOUNT"`
 3.  `"PAYMENT_ONGOING"`
 4. `"PAYMENT_EXPIRED"`
 5. `"PAYMENT_UNAVAILABLE"`
 6. `"PAYMENT_UNKNOWN"`
 7. `"DOMAIN_UNKNOWN"`

In order to ensure the backward compatibility of the _pagopa-proxy_ clients (for example _App IO_), these errors will continue to be handled as currently defined and then in a second phase these will also be replaced with the error codes as well as define from _pagoPA Node_.

For further details see this [page](https://pagopa.atlassian.net/wiki/spaces/PAG/pages/384141710/RFC+App+IO+-+pagopa-proxy+Gestione+codici+di+errore).

> _pagopa-proxy_'ll set `detail_v2` new field with the value of [originalFaultCode](https://github.com/pagopa/pagopa-api/blob/0e94c72d64af367e917f12c8e4112674b4d92c0c/nodo/NodoPerPsp.wsdl#L118) come back from Nodo.
#####
Example 1

######
Old Error Response

```json
{  
  "status": 500,
  "title": "Internal server error",
  "detail": "PAYMENT_ONGOING" 
}
```
######
New Error Response

```json
{  
  "status": 500,
  "title": "Internal server error",
  "detail": "PAYMENT_ONGOING",
  "detail_v2": "PAA_PAGAMENTO_IN_CORSO" 
}
```

#####
Example 2

######
Old Error Response

```json
{  
  "status": 500,
  "title": "Internal server error",
  "detail": "PAYMENT_UNAVAILABLE" 
}
```
######
New Error Response

```json
{  
  "status": 500,
  "title": "Internal server error",
  "detail": "PAYMENT_UNAVAILABLE",
  "detail_v2": "PPT_IBAN_NON_CENSITO" 
}
```

#### How Has This Been Tested?

Run app locally in docker environment or run unit test, in particular [PaymentConverter.test.ts](https://github.com/pagopa/io-pagopa-proxy/blob/0d3fcbd61564df5bd97f9fbd89d57eec8df840b7/src/utils/__tests__/PaymentConverter.test.ts#L399)

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
