### PR TITLE
[IOPAY-423] add check to set enteBeneficiario

### DIFF
--- a/src/utils/PaymentsConverter.ts
+++ b/src/utils/PaymentsConverter.ts
@@ -319,14 +319,10 @@ export function getActivateIOPaymentResponse(
           causaleVersamento: activateIOPaymentRes.paymentDescription
             ? activateIOPaymentRes.paymentDescription
             : undefined,
-          enteBeneficiario: {
-            identificativoUnivocoBeneficiario: activateIOPaymentRes.fiscalCodePA
-              ? activateIOPaymentRes.fiscalCodePA
-              : undefined,
+          enteBeneficiario: activateIOPaymentRes.fiscalCodePA && activateIOPaymentRes.companyName ? {
+            identificativoUnivocoBeneficiario: activateIOPaymentRes.fiscalCodePA,
             denominazioneBeneficiario: activateIOPaymentRes.companyName
-              ? activateIOPaymentRes.companyName
-              : undefined
-          }
+          } : undefined
         }
       : undefined;
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- added check to set `enteBeneficiario` only if both `fiscalCodePA` and `companyName` are set.

#### Motivation and Context

The goal of this PR is to add check  to set `enteBeneficiario` only if both `fiscalCodePA` and `companyName` are set in `activateIOPaymentRes_nfpsp`, according to [API specs](https://github.com/pagopa/io-pagopa-proxy/blob/266c8cfbe2df773de2a1d8dfd13c74c40091afe2/api_pagopa.yaml#L220).

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
