### PR TITLE
[IOPAY-403] hotfix

### DIFF
--- a/src/utils/PaymentsConverter.ts
+++ b/src/utils/PaymentsConverter.ts
@@ -326,14 +326,15 @@ export function getActivateIOPaymentResponse(
           causaleVersamento: activateIOPaymentRes.paymentDescription
             ? activateIOPaymentRes.paymentDescription
             : undefined,
-          enteBeneficiario: {
-            identificativoUnivocoBeneficiario: activateIOPaymentRes.fiscalCodePA
-              ? activateIOPaymentRes.fiscalCodePA
-              : undefined,
-            denominazioneBeneficiario: activateIOPaymentRes.companyName
-              ? activateIOPaymentRes.companyName
+          enteBeneficiario:
+            activateIOPaymentRes.fiscalCodePA &&
+            activateIOPaymentRes.companyName
+              ? {
+                  identificativoUnivocoBeneficiario:
+                    activateIOPaymentRes.fiscalCodePA,
+                  denominazioneBeneficiario: activateIOPaymentRes.companyName
+                }
               : undefined
-          }
         }
       : undefined;
 

--- a/src/utils/PaymentsConverter.ts
+++ b/src/utils/PaymentsConverter.ts
@@ -209,7 +209,6 @@ export function getPaymentRequestsGetResponseNm3(
             identificativoUnivocoBeneficiario:
               verifyPaymentNoticeResponse.fiscalCodePA,
             denominazioneBeneficiario: verifyPaymentNoticeResponse.companyName,
-            codiceUnitOperBeneficiario: verifyPaymentNoticeResponse.officeName,
             denomUnitOperBeneficiario: verifyPaymentNoticeResponse.officeName
           }
         }

--- a/src/utils/__tests__/MockedData.ts
+++ b/src/utils/__tests__/MockedData.ts
@@ -8,6 +8,8 @@ import { esitoNodoVerificaRPTRisposta_type_ppt } from "../../../generated/Pagame
 import { PagoPAConfig } from "../../Configuration";
 import * as E from "fp-ts/Either";
 import { RptId } from "../pagopa";
+import { activateIOPaymentRes_element_nfpsp } from "../../../generated/nodeNm3io/activateIOPaymentRes_element_nfpsp";
+import { ValidationError } from "io-ts";
 
 // tslint:disable:no-identical-functions
 
@@ -427,3 +429,48 @@ export const aSpezzoniCausaleVersamentoStrutturatoForController = pipe(ctSpezzon
       throw Error(`Invalid configuration: ${reporters.readableReport(errors)}`);
     })
   );
+
+  export const activateIOPaymentResOutputWhitoutEnte = pipe(activateIOPaymentRes_element_nfpsp
+  .decode({
+    outcome: "OK",
+    totalAmount: 100,
+    paymentDescription: "Test causale senza ente"
+  }),
+  E.getOrElseW((errors: readonly ValidationError[]) => {
+    throw Error(
+      `Invalid activateIOPaymentRes_nfpsp to decode: ${reporters.readableReport(
+        errors
+      )}`
+    );
+  }));
+
+export const activateIOPaymentResOutputWhithInvalidEnte = pipe(activateIOPaymentRes_element_nfpsp
+  .decode({
+    outcome: "OK",
+    totalAmount: 100,
+    paymentDescription: "Test causale",
+    fiscalCodePA: "77777777777"
+  }),
+  E.getOrElseW((errors: readonly ValidationError[]) => {
+    throw Error(
+      `Invalid activateIOPaymentRes_nfpsp to decode: ${reporters.readableReport(
+        errors
+      )}`
+    );
+  }));
+
+export const activateIOPaymentResOutputWhithEnte = pipe(activateIOPaymentRes_element_nfpsp
+  .decode({
+    outcome: "OK",
+    totalAmount: 100,
+    paymentDescription: "Test causale",
+    fiscalCodePA: "77777777777",
+    companyName: "denominazione"
+  }),
+  E.getOrElseW((errors: readonly ValidationError[]) => {
+    throw Error(
+      `Invalid activateIOPaymentRes_nfpsp to decode: ${reporters.readableReport(
+        errors
+      )}`
+    );
+  }));

--- a/src/utils/__tests__/PaymentConverter.test.ts
+++ b/src/utils/__tests__/PaymentConverter.test.ts
@@ -611,3 +611,80 @@ describe("getErrorMessageCtrlFromPagoPaError", () => {
     expect(errorMsg).toEqual("PPT_ERRORE_EMESSO_DA_PAA");
   });
 });
+
+describe("getActivateIOPaymentResponse", () => {
+  it("should convert activateIOPaymentRes_nfpsp with valid Ente in PaymentActivationsPostResponse", () => {
+    const errorOrPaymentActivationsPostResponse = PaymentsConverter.getActivateIOPaymentResponse(
+      MockedData.activateIOPaymentResOutputWhithEnte
+    );
+    expect(isRight(errorOrPaymentActivationsPostResponse)).toBeTruthy();
+    if (!isRight(errorOrPaymentActivationsPostResponse)) {
+      return;
+    }
+    expect(
+      errorOrPaymentActivationsPostResponse.right.importoSingoloVersamento
+    ).toBe(10000);
+    expect(
+      errorOrPaymentActivationsPostResponse.right.enteBeneficiario
+        ? errorOrPaymentActivationsPostResponse.right.enteBeneficiario
+            .denominazioneBeneficiario
+        : undefined
+    ).toBe("denominazione");
+    expect(
+      errorOrPaymentActivationsPostResponse.right.enteBeneficiario
+        ? errorOrPaymentActivationsPostResponse.right.enteBeneficiario
+            .identificativoUnivocoBeneficiario
+        : undefined
+    ).toBe("77777777777");
+  });
+
+  it("should convert activateIOPaymentRes_nfpsp with invalid Ente in PaymentActivationsPostResponse", () => {
+    const errorOrPaymentActivationsPostResponse = PaymentsConverter.getActivateIOPaymentResponse(
+      MockedData.activateIOPaymentResOutputWhithInvalidEnte
+    );
+    expect(isRight(errorOrPaymentActivationsPostResponse)).toBeTruthy();
+    if (!isRight(errorOrPaymentActivationsPostResponse)) {
+      return;
+    }
+    expect(
+      errorOrPaymentActivationsPostResponse.right.importoSingoloVersamento
+    ).toBe(10000);
+    expect(
+      errorOrPaymentActivationsPostResponse.right.enteBeneficiario
+        ? errorOrPaymentActivationsPostResponse.right.enteBeneficiario
+            .denominazioneBeneficiario
+        : undefined
+    ).toBeUndefined();
+    expect(
+      errorOrPaymentActivationsPostResponse.right.enteBeneficiario
+        ? errorOrPaymentActivationsPostResponse.right.enteBeneficiario
+            .identificativoUnivocoBeneficiario
+        : undefined
+    ).toBeUndefined();
+  });
+
+  it("should convert activateIOPaymentRes_nfpsp without Ente in getActivateIOPaymentResponse", () => {
+    const errorOrPaymentActivationsPostResponse = PaymentsConverter.getActivateIOPaymentResponse(
+      MockedData.activateIOPaymentResOutputWhitoutEnte
+    );
+    expect(isRight(errorOrPaymentActivationsPostResponse)).toBeTruthy();
+    if (!isRight(errorOrPaymentActivationsPostResponse)) {
+      return;
+    }
+    expect(
+      errorOrPaymentActivationsPostResponse.right.importoSingoloVersamento
+    ).toBe(10000);
+    expect(
+      errorOrPaymentActivationsPostResponse.right.enteBeneficiario
+        ? errorOrPaymentActivationsPostResponse.right.enteBeneficiario
+            .denominazioneBeneficiario
+        : undefined
+    ).toBeUndefined();
+    expect(
+      errorOrPaymentActivationsPostResponse.right.enteBeneficiario
+        ? errorOrPaymentActivationsPostResponse.right.enteBeneficiario
+            .identificativoUnivocoBeneficiario
+        : undefined
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- [[PGP-6] disable codiceUnitOperBeneficiario for nm3 by infantesimone · Pull Request #328 · pagopa/io-pagopa-proxy](https://github.com/pagopa/io-pagopa-proxy/pull/328) 

- [[IOPAY-423] add check to set enteBeneficiario by infantesimone · Pull Request #327 · pagopa/io-pagopa-proxy](https://github.com/pagopa/io-pagopa-proxy/pull/327)
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


[PGP-6]: https://pagopa.atlassian.net/browse/PGP-6?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IOPAY-423]: https://pagopa.atlassian.net/browse/IOPAY-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ