### PR TITLE
[CHK-363] Segregate response types and HTTP status codes by Nodo faults

### DIFF
--- a/api-spec/api-for-io.yaml
+++ b/api-spec/api-for-io.yaml
@@ -354,6 +354,7 @@ definitions:
   PaymentFaultV2:
     description: |-
       This enumeration includes all possible fault codes for the PagoPA/Controparte Verifica ([`getPaymentInfo`](#/default/getPaymentInfo)) and Attiva ([`activatePayment`](#/default/activatePayment)) operations.
+      For further information visit https://docs.pagopa.it/gestionedeglierrori/struttura-degli-errori/fault-code.
       Possible fault codes are:
         - `PPT_SYSTEM_ERROR`
         - `PPT_AUTORIZZAZIONE`

--- a/api-spec/api-for-io.yaml
+++ b/api-spec/api-for-io.yaml
@@ -328,7 +328,18 @@ definitions:
       importoSpezzone:
         $ref: '#/definitions/ImportoEuroCents'
   PaymentFault:
-    description: Fault codes for the PagoPA Verifica and Attiva operations ( Deprecated )
+    description: |-
+      DEPRECATED. Fault codes for the PagoPA Verifica and Attiva operations.
+      Possible fault codes are:
+      - `PAYMENT_DUPLICATED`
+      - `INVALID_AMOUNT`
+      - `PAYMENT_ONGOING`
+      - `PAYMENT_EXPIRED`
+      - `PAYMENT_UNAVAILABLE`
+      - `PAYMENT_UNKNOWN`
+      - `DOMAIN_UNKNOWN`
+      - `PPT_MULTI_BENEFICIARIO`
+      - `GENERIC_ERROR`
     type: string
     x-extensible-enum:
       - PAYMENT_DUPLICATED
@@ -341,7 +352,119 @@ definitions:
       - PPT_MULTI_BENEFICIARIO
       - GENERIC_ERROR
   PaymentFaultV2:
-    description: Fault codes for the PagoPA/Controparte Verifica and Attiva operations
+    description: |-
+      This enumeration includes all possible fault codes for the PagoPA/Controparte Verifica ([`getPaymentInfo`](#/default/getPaymentInfo)) and Attiva ([`activatePayment`](#/default/activatePayment)) operations.
+      Possible fault codes are:
+        - `PPT_SYSTEM_ERROR`
+        - `PPT_AUTORIZZAZIONE`
+        - `PPT_AUTENTICAZIONE`
+        - `PPT_SINTASSI_XSD`
+        - `PPT_SINTASSI_EXTRAXSD`
+        - `PPT_SEMANTICA`
+        - `PPT_RPT_DUPLICATA`
+        - `PPT_RPT_SCONOSCIUTA`
+        - `PPT_RT_SCONOSCIUTA`
+        - `PPT_RT_NONDISPONIBILE`
+        - `PPT_SUPERAMENTOSOGLIA`
+        - `PPT_SEGREGAZIONE`
+        - `PPT_TIPOFIRMA_SCONOSCIUTO`
+        - `PPT_ERRORE_FORMATO_BUSTA_FIRMATA`
+        - `PPT_FIRMA_INDISPONIBILE`
+        - `PPT_ID_CARRELLO_DUPLICATO`
+        - `PPT_OPER_NON_STORNABILE`
+        - `PPT_OPER_NON_REVOCABILE`
+        - `PPT_WISP_TIMEOUT_RECUPERO_SCELTA`
+        - `PPT_WISP_SESSIONE_SCONOSCIUTA`
+        - `PPT_CANALE_ERRORE`
+        - `PPT_CODIFICA_PSP_SCONOSCIUTA`
+        - `PPT_PSP_SCONOSCIUTO`
+        - `PPT_PSP_DISABILITATO`
+        - `PPT_TIPO_VERSAMENTO_SCONOSCIUTO`
+        - `PPT_INTERMEDIARIO_PSP_SCONOSCIUTO`
+        - `PPT_INTERMEDIARIO_PSP_DISABILITATO`
+        - `PPT_CANALE_IRRAGGIUNGIBILE`
+        - `PPT_CANALE_SERVIZIO_NONATTIVO`
+        - `PPT_CANALE_TIMEOUT`
+        - `PPT_CANALE_NONRISOLVIBILE`
+        - `PPT_CANALE_INDISPONIBILE`
+        - `PPT_CANALE_SCONOSCIUTO`
+        - `PPT_CANALE_DISABILITATO`
+        - `PPT_CANALE_ERR_PARAM_PAG_IMM`
+        - `PPT_CANALE_ERRORE_RESPONSE`
+        - `PPT_RT_DUPLICATA`
+        - `PPT_ISCRIZIONE_NON_PRESENTE`
+        - `PPT_ULTERIORE_ISCRIZIONE`
+        - `PPT_PDD_IRRAGGIUNGIBILE`
+        - `PPT_ERRORE_EMESSO_DA_PAA`
+        - `PPT_DOMINIO_SCONOSCIUTO`
+        - `PPT_DOMINIO_DISABILITATO`
+        - `PPT_INTERMEDIARIO_PA_SCONOSCIUTO`
+        - `PPT_INTERMEDIARIO_PA_DISABILITATO`
+        - `PPT_STAZIONE_INT_PA_IRRAGGIUNGIBILE`
+        - `PPT_STAZIONE_INT_PA_SERVIZIO_NONATTIVO`
+        - `PPT_STAZIONE_INT_PA_ERRORE_RESPONSE`
+        - `PPT_STAZIONE_INT_PA_TIMEOUT`
+        - `PPT_STAZIONE_INT_PA_NONRISOLVIBILE`
+        - `PPT_STAZIONE_INT_PA_INDISPONIBILE`
+        - `PPT_STAZIONE_INT_PA_SCONOSCIUTA`
+        - `PPT_STAZIONE_INT_PA_DISABILITATA`
+        - `PPT_ID_FLUSSO_SCONOSCIUTO`
+        - `PAA_ID_DOMINIO_ERRATO`
+        - `PAA_ID_INTERMEDIARIO_ERRATO`
+        - `PAA_STAZIONE_INT_ERRATA`
+        - `PAA_RPT_SCONOSCIUTA`
+        - `PAA_RT_DUPLICATA`
+        - `PAA_TIPOFIRMA_SCONOSCIUTO`
+        - `PAA_ERRORE_FORMATO_BUSTA_FIRMATA`
+        - `PAA_FIRMA_INDISPONIBILE`
+        - `PAA_FIRMA_ERRATA`
+        - `PAA_PAGAMENTO_SCONOSCIUTO`
+        - `PAA_PAGAMENTO_DUPLICATO`
+        - `PAA_PAGAMENTO_IN_CORSO`
+        - `PAA_PAGAMENTO_ANNULLATO`
+        - `PAA_PAGAMENTO_SCADUTO`
+        - `PAA_SINTASSI_XSD`
+        - `PAA_SINTASSI_EXTRAXSD`
+        - `PAA_SEMANTICA`
+        - `PAA_ATTIVA_RPT_IMPORTO_NON_VALIDO`
+        - `PAA_SYSTEM_ERROR`
+        - `CANALE_SINTASSI_XSD`
+        - `CANALE_SINTASSI_EXTRAXSD`
+        - `CANALE_SEMANTICA`
+        - `CANALE_RPT_DUPLICATA`
+        - `CANALE_RPT_SCONOSCIUTA`
+        - `CANALE_RPT_RIFIUTATA`
+        - `CANALE_RT_SCONOSCIUTA`
+        - `CANALE_RT_NON_DISPONIBILE`
+        - `CANALE_INDISPONIBILE`
+        - `CANALE_RICHIEDENTE_ERRATO`
+        - `CANALE_SYSTEM_ERROR`
+        - `PPT_LOCAL_ERROR_PROTOCOLLO`
+        - `PPT_LOCAL_ERROR_EXTRAXSD`
+        - `PPT_LOCAL_ERROR_FSM`
+        - `PPT_RT_SEGNO_DISCORDE`
+        - `CANALE_FIRMA_SCONOSCIUTA`
+        - `CANALE_BUSTA_ERRATA`
+        - `CANALE_NEGA_CONTABILIZZAZIONE`
+        - `CANALE_CARRELLO_DUPLICATO_KO`
+        - `CANALE_CARRELLO_DUPLICATO_UNKNOWN`
+        - `CANALE_CARRELLO_DUPLICATO_OK`
+        - `OGGETTO_DISABILITATO`
+        - `PPT_IBAN_NON_CENSITO`
+        - `PPT_RT_IN_GESTIONE`
+        - `CANALE_CONVENZIONE_NON_VALIDA`
+        - `PAA_CONVENZIONE_NON_VALIDA`
+        - `PPT_IMPORTO_ERRATO`
+        - `PPT_TOKEN_SCONOSCIUTO`
+        - `PPT_TOKEN_SCADUTO`
+        - `PPT_POSIZIONE_SCONOSCIUTA`
+        - `PPT_DATI_POSIZIONE_GIA_CONOSCIUTI`
+        - `PPT_ESITO_GIA_ACQUISITO`
+        - `PPT_PAGAMENTO_IN_CORSO`
+        - `PPT_PAGAMENTO_DUPLICATO`
+        - `PPT_MULTI_BENEFICIARIO`
+        - `PPT_ERRORE`
+        - `GENERIC_ERROR`
     type: string
     x-extensible-enum:
       - PPT_SYSTEM_ERROR

--- a/api-spec/api-pagopa-proxy.yaml
+++ b/api-spec/api-pagopa-proxy.yaml
@@ -29,14 +29,14 @@ paths:
           description: Invalid input
           schema:
             $ref: "#/definitions/ProblemJson"
-        "424":
-          description: PagoPA services are not available or request is rejected by PagoPa
-          schema:
-            $ref: "#/definitions/PaymentProblemJson"   
         '500':
           description: Generic server error
           schema:
             $ref: "#/definitions/ProblemJson"
+        "502":
+          description: PagoPA services are not available or request is rejected by PagoPa
+          schema:
+            $ref: "#/definitions/PaymentProblemJson"
         '504':
           description: Timeout from PagoPA services
           schema:
@@ -71,14 +71,14 @@ paths:
           description: Invalid input
           schema:
             $ref: "#/definitions/ProblemJson"
-        "424":
-          description: PagoPA services are not available or request is rejected by PagoPa
-          schema:
-            $ref: "#/definitions/PaymentProblemJson"
         '500':
           description: Generic server error
           schema:
             $ref: "#/definitions/ProblemJson"
+        "502":
+          description: PagoPA services are not available or request is rejected by PagoPa
+          schema:
+            $ref: "#/definitions/PaymentProblemJson"
         '504':
           description: Timeout from PagoPA services
           schema:
@@ -108,12 +108,12 @@ paths:
           description: Activation status not found
           schema:
             $ref: "#/definitions/ProblemJson"
-        '424':
-          description: PagoPA services answered request with error
-          schema:
-            $ref: "#/definitions/ProblemJson"
         '500':
           description: Generic server error
+          schema:
+            $ref: "#/definitions/ProblemJson"
+        '502':
+          description: PagoPA services answered request with error
           schema:
             $ref: "#/definitions/ProblemJson"
 definitions:

--- a/api-spec/api-pagopa-proxy.yaml
+++ b/api-spec/api-pagopa-proxy.yaml
@@ -28,19 +28,19 @@ paths:
         '400':
           description: Invalid input
           schema:
-            $ref: "#/definitions/ProblemJson"
-        '500':
-          description: Generic server error
-          schema:
-            $ref: "#/definitions/ProblemJson"
+            $ref: "#/definitions/PartyConfigurationFaultPaymentProblemJson"
         "502":
           description: PagoPA services are not available or request is rejected by PagoPa
           schema:
-            $ref: "#/definitions/PaymentProblemJson"
+            $ref: "#/definitions/GatewayFaultPaymentProblemJson"
         '504':
           description: Timeout from PagoPA services
           schema:
-            $ref: "#/definitions/PaymentProblemJson"
+            $ref: "#/definitions/PartyTimeoutFaultPaymentProblemJson"
+        '598':
+          description: Service connection error while connecting to PagoPA services
+          schema:
+            $ref: "#/definitions/PartyConnectionFaultPaymentProblemJson"
   '/payment-activations':
     x-swagger-router-controller: PaymentController
     post:
@@ -70,19 +70,19 @@ paths:
         '400':
           description: Invalid input
           schema:
-            $ref: "#/definitions/ProblemJson"
-        '500':
-          description: Generic server error
-          schema:
-            $ref: "#/definitions/ProblemJson"
+            $ref: "#/definitions/PartyConfigurationFaultPaymentProblemJson"
         "502":
           description: PagoPA services are not available or request is rejected by PagoPa
           schema:
-            $ref: "#/definitions/PaymentProblemJson"
+            $ref: "#/definitions/GatewayFaultPaymentProblemJson"
         '504':
           description: Timeout from PagoPA services
           schema:
-            $ref: "#/definitions/PaymentProblemJson"
+            $ref: "#/definitions/PartyTimeoutFaultPaymentProblemJson"
+        '598':
+          description: Service connection error while connecting to PagoPA services
+          schema:
+            $ref: "#/definitions/PartyConnectionFaultPaymentProblemJson"
   '/payment-activations/{codice_contesto_pagamento}':
     x-swagger-router-controller: PaymentController
     get:
@@ -103,19 +103,15 @@ paths:
         '400':
           description: Invalid input
           schema:
-            $ref: "#/definitions/ProblemJson"
+            $ref: "#/definitions/PartyConfigurationFaultPaymentProblemJson"
         '404':
           description: Activation status not found
           schema:
             $ref: "#/definitions/ProblemJson"
-        '500':
-          description: Generic server error
+        "502":
+          description: PagoPA services are not available or request is rejected by PagoPa
           schema:
-            $ref: "#/definitions/ProblemJson"
-        '502':
-          description: PagoPA services answered request with error
-          schema:
-            $ref: "#/definitions/ProblemJson"
+            $ref: "#/definitions/GatewayFaultPaymentProblemJson"
 definitions:
   ProblemJson:
     $ref: "https://raw.githubusercontent.com/teamdigitale/digital-citizenship-functions/v0.51.0/api/definitions.yaml#/ProblemJson"
@@ -148,6 +144,158 @@ definitions:
         $ref: "#/definitions/PaymentFault"
       detail_v2:
         $ref: "#/definitions/PaymentFaultV2"
+      instance:
+        type: string
+        format: uri
+        description: |-
+          An absolute URI that identifies the specific occurrence of the problem.
+          It may or may not yield further information if dereferenced.
+    required:
+      - detail
+      - detail_v2
+  GatewayFaultPaymentProblemJson:
+    description: TODO - A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations
+    type: object
+    properties:
+      type:
+        type: string
+        format: uri
+        description: |-
+          An absolute URI that identifies the problem type. When dereferenced,
+          it SHOULD provide human-readable documentation for the problem type
+          (e.g., using HTML).
+        default: about:blank
+        example: https://example.com/problem/constraint-violation
+      title:
+        type: string
+        description: |-
+          A short, summary of the problem type. Written in english and readable
+          for engineers (usually not suited for non technical stakeholders and
+          not localized); example: Service Unavailable
+      status:
+        type: integer
+        format: int32
+        minimum: 100
+        maximum: 600
+        exclusiveMaximum: true
+      detail:
+        $ref: "#/definitions/PaymentFault"
+      detail_v2:
+        $ref: "#/definitions/GatewayFault"
+      instance:
+        type: string
+        format: uri
+        description: |-
+          An absolute URI that identifies the specific occurrence of the problem.
+          It may or may not yield further information if dereferenced.
+    required:
+      - detail
+      - detail_v2
+  PartyConfigurationFaultPaymentProblemJson:
+    description: TODO - A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations
+    type: object
+    properties:
+      type:
+        type: string
+        format: uri
+        description: |-
+          An absolute URI that identifies the problem type. When dereferenced,
+          it SHOULD provide human-readable documentation for the problem type
+          (e.g., using HTML).
+        default: about:blank
+        example: https://example.com/problem/constraint-violation
+      title:
+        type: string
+        description: |-
+          A short, summary of the problem type. Written in english and readable
+          for engineers (usually not suited for non technical stakeholders and
+          not localized); example: Service Unavailable
+      status:
+        type: integer
+        format: int32
+        minimum: 100
+        maximum: 600
+        exclusiveMaximum: true
+      detail:
+        $ref: "#/definitions/PaymentFault"
+      detail_v2:
+        $ref: "#/definitions/PartyConfigurationFault"
+      instance:
+        type: string
+        format: uri
+        description: |-
+          An absolute URI that identifies the specific occurrence of the problem.
+          It may or may not yield further information if dereferenced.
+    required:
+      - detail
+      - detail_v2
+  PartyConnectionFaultPaymentProblemJson:
+    description: TODO - A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations
+    type: object
+    properties:
+      type:
+        type: string
+        format: uri
+        description: |-
+          An absolute URI that identifies the problem type. When dereferenced,
+          it SHOULD provide human-readable documentation for the problem type
+          (e.g., using HTML).
+        default: about:blank
+        example: https://example.com/problem/constraint-violation
+      title:
+        type: string
+        description: |-
+          A short, summary of the problem type. Written in english and readable
+          for engineers (usually not suited for non technical stakeholders and
+          not localized); example: Service Unavailable
+      status:
+        type: integer
+        format: int32
+        minimum: 100
+        maximum: 600
+        exclusiveMaximum: true
+      detail:
+        $ref: "#/definitions/PaymentFault"
+      detail_v2:
+        $ref: "#/definitions/PartyConnectionFault"
+      instance:
+        type: string
+        format: uri
+        description: |-
+          An absolute URI that identifies the specific occurrence of the problem.
+          It may or may not yield further information if dereferenced.
+    required:
+      - detail
+      - detail_v2
+  PartyTimeoutFaultPaymentProblemJson:
+    description: TODO - A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations
+    type: object
+    properties:
+      type:
+        type: string
+        format: uri
+        description: |-
+          An absolute URI that identifies the problem type. When dereferenced,
+          it SHOULD provide human-readable documentation for the problem type
+          (e.g., using HTML).
+        default: about:blank
+        example: https://example.com/problem/constraint-violation
+      title:
+        type: string
+        description: |-
+          A short, summary of the problem type. Written in english and readable
+          for engineers (usually not suited for non technical stakeholders and
+          not localized); example: Service Unavailable
+      status:
+        type: integer
+        format: int32
+        minimum: 100
+        maximum: 600
+        exclusiveMaximum: true
+      detail:
+        $ref: "#/definitions/PaymentFault"
+      detail_v2:
+        $ref: "#/definitions/PartyTimeoutFault"
       instance:
         type: string
         format: uri
@@ -320,6 +468,51 @@ definitions:
       - DOMAIN_UNKNOWN
       - PPT_MULTI_BENEFICIARIO
       - GENERIC_ERROR
+  GatewayFault:
+    description: TODO - mapped to 502
+    type: string
+    x-extensible-enum:
+      - PPT_SINTASSI_EXTRAXSD
+      - PPT_SINTASSI_XSD
+      - PPT_PSP_SCONOSCIUTO
+      - PPT_PSP_DISABILITATO
+      - PPT_INTERMEDIARIO_PSP_SCONOSCIUTO
+      - PPT_INTERMEDIARIO_PSP_DISABILITATO
+      - PPT_CANALE_SCONOSCIUTO
+      - PPT_CANALE_DISABILITATO
+      - PPT_AUTENTICAZIONE
+      - PPT_AUTORIZZAZIONE
+      - PPT_DOMINIO_DISABILITATO
+      - PPT_INTERMEDIARIO_PA_DISABILITATO
+      - PPT_STAZIONE_INT_PA_DISABILITATA
+      - PPT_CODIFICA_PSP_SCONOSCIUTA
+      - PPT_SEMANTICA
+      - PPT_ERRORE_EMESSO_DA_PAA
+      - PPT_STAZIONE_INT_PA_ERRORE_RESPONSE
+      - PPT_IBAN_NON_CENSITO
+      - PPT_SYSTEM_ERROR
+  PartyConfigurationFault:
+    description: TODO - mapped to 400
+    type: string
+    x-extensible-enum:
+      - PPT_DOMINIO_SCONOSCIUTO
+      - PPT_INTERMEDIARIO_PA_SCONOSCIUTO
+      - PPT_STAZIONE_INT_PA_SCONOSCIUTA
+      - PPT_PAGAMENTO_IN_CORSO
+      - PPT_PAGAMENTO_DUPLICATO
+  PartyConnectionFault:
+    description: TODO - mapped to 598?
+    type: string
+    x-extensible-enum:
+      - PPT_STAZIONE_INT_PA_IRRAGGIUNGIBILE
+      - PPT_STAZIONE_INT_PA_SERVIZIO_NONATTIVO
+  PartyTimeoutFault:
+    description: TODO - mapped to 504
+    type: string
+    x-extensible-enum:
+      - PPT_STAZIONE_INT_PA_TIMEOUT
+      - GENERIC_ERROR
+
   PaymentFaultV2:
     description: Fault codes for the PagoPA/Controparte Verifica and Attiva operations
     type: string

--- a/api-spec/api-pagopa-proxy.yaml
+++ b/api-spec/api-pagopa-proxy.yaml
@@ -28,11 +28,15 @@ paths:
         '400':
           description: Invalid input
           schema:
-            $ref: "#/definitions/PartyConfigurationFaultPaymentProblemJson"
+            $ref: "#/definitions/ValidationFaultPaymentProblemJson"
         "502":
           description: PagoPA services are not available or request is rejected by PagoPa
           schema:
             $ref: "#/definitions/GatewayFaultPaymentProblemJson"
+        "503":
+          description: EC services are not available
+          schema:
+            $ref: "#/definitions/PartyConfigurationFaultPaymentProblemJson"
         '504':
           description: Timeout from PagoPA services
           schema:
@@ -70,11 +74,15 @@ paths:
         '400':
           description: Invalid input
           schema:
-            $ref: "#/definitions/PartyConfigurationFaultPaymentProblemJson"
+            $ref: "#/definitions/ValidationFaultPaymentProblemJson"
         "502":
           description: PagoPA services are not available or request is rejected by PagoPa
           schema:
             $ref: "#/definitions/GatewayFaultPaymentProblemJson"
+        "503":
+          description: EC services are not available
+          schema:
+            $ref: "#/definitions/PartyConfigurationFaultPaymentProblemJson"
         '504':
           description: Timeout from PagoPA services
           schema:
@@ -103,7 +111,7 @@ paths:
         '400':
           description: Invalid input
           schema:
-            $ref: "#/definitions/PartyConfigurationFaultPaymentProblemJson"
+            $ref: "#/definitions/ValidationFaultPaymentProblemJson"
         '404':
           description: Activation status not found
           schema:
@@ -153,8 +161,50 @@ definitions:
     required:
       - detail
       - detail_v2
+  ValidationFaultPaymentProblemJson:
+    description: |-
+      A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.
+      Possible values of `detail_v2` are limited to faults pertaining to validation errors.
+    type: object
+    properties:
+      type:
+        type: string
+        format: uri
+        description: |-
+          An absolute URI that identifies the problem type. When dereferenced,
+          it SHOULD provide human-readable documentation for the problem type
+          (e.g., using HTML).
+        default: about:blank
+        example: https://example.com/problem/constraint-violation
+      title:
+        type: string
+        description: |-
+          A short, summary of the problem type. Written in english and readable
+          for engineers (usually not suited for non technical stakeholders and
+          not localized); example: Service Unavailable
+      status:
+        type: integer
+        format: int32
+        minimum: 100
+        maximum: 600
+        exclusiveMaximum: true
+      detail:
+        $ref: "#/definitions/PaymentFault"
+      detail_v2:
+        $ref: "#/definitions/ValidationFault"
+      instance:
+        type: string
+        format: uri
+        description: |-
+          An absolute URI that identifies the specific occurrence of the problem.
+          It may or may not yield further information if dereferenced.
+    required:
+      - detail
+      - detail_v2
   GatewayFaultPaymentProblemJson:
-    description: TODO - A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations
+    description: |-
+      A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.
+      Possible values of `detail_v2` are limited to faults pertaining to Nodo errors.
     type: object
     properties:
       type:
@@ -192,7 +242,9 @@ definitions:
       - detail
       - detail_v2
   PartyConfigurationFaultPaymentProblemJson:
-    description: TODO - A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations
+    description: |-
+      A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.
+      Possible values of `detail_v2` are limited to faults pertaining to EC non-fatal errors.
     type: object
     properties:
       type:
@@ -468,11 +520,20 @@ definitions:
       - DOMAIN_UNKNOWN
       - PPT_MULTI_BENEFICIARIO
       - GENERIC_ERROR
+  ValidationFault:
+    description: TODO - mapped to 400
+    type: string
+    x-extensible-enum:
+      - PPT_DOMINIO_SCONOSCIUTO
+      - PPT_INTERMEDIARIO_PA_SCONOSCIUTO
+      - PPT_STAZIONE_INT_PA_SCONOSCIUTA
   GatewayFault:
     description: TODO - mapped to 502
     type: string
     x-extensible-enum:
       - GENERIC_ERROR
+      - PPT_PAGAMENTO_IN_CORSO
+      - PPT_PAGAMENTO_DUPLICATO
       - PPT_SINTASSI_EXTRAXSD
       - PPT_SINTASSI_XSD
       - PPT_PSP_SCONOSCIUTO
@@ -483,26 +544,21 @@ definitions:
       - PPT_CANALE_DISABILITATO
       - PPT_AUTENTICAZIONE
       - PPT_AUTORIZZAZIONE
+      - PPT_CODIFICA_PSP_SCONOSCIUTA
+      - PPT_SEMANTICA
+      - PPT_SYSTEM_ERROR
+  PartyConfigurationFault:
+    description: TODO - mapped to 503
+    type: string
+    x-extensible-enum:
       - PPT_DOMINIO_DISABILITATO
       - PPT_INTERMEDIARIO_PA_DISABILITATO
       - PPT_STAZIONE_INT_PA_DISABILITATA
-      - PPT_CODIFICA_PSP_SCONOSCIUTA
-      - PPT_SEMANTICA
       - PPT_ERRORE_EMESSO_DA_PAA
       - PPT_STAZIONE_INT_PA_ERRORE_RESPONSE
       - PPT_IBAN_NON_CENSITO
-      - PPT_SYSTEM_ERROR
-  PartyConfigurationFault:
-    description: TODO - mapped to 400
-    type: string
-    x-extensible-enum:
-      - PPT_DOMINIO_SCONOSCIUTO
-      - PPT_INTERMEDIARIO_PA_SCONOSCIUTO
-      - PPT_STAZIONE_INT_PA_SCONOSCIUTA
-      - PPT_PAGAMENTO_IN_CORSO
-      - PPT_PAGAMENTO_DUPLICATO
   PartyConnectionFault:
-    description: TODO - mapped to 598?
+    description: TODO - mapped to 598
     type: string
     x-extensible-enum:
       - PPT_STAZIONE_INT_PA_IRRAGGIUNGIBILE

--- a/api-spec/api-pagopa-proxy.yaml
+++ b/api-spec/api-pagopa-proxy.yaml
@@ -552,7 +552,7 @@ definitions:
       - PPT_SEMANTICA
       - PPT_SYSTEM_ERROR
   PartyConfigurationFault:
-    description: Fault codes for , should be mapped to 503 HTTP status code.
+    description: Fault codes for fatal errors from ECs, should be mapped to 503 HTTP status code.
     type: string
     x-extensible-enum:
       - PPT_DOMINIO_DISABILITATO
@@ -562,13 +562,13 @@ definitions:
       - PPT_STAZIONE_INT_PA_ERRORE_RESPONSE
       - PPT_IBAN_NON_CENSITO
   PartyConnectionFault:
-    description: TODO - mapped to 598
+    description: Fault codes for connection errors to ECs, should be mapped to 598 HTTP status code.
     type: string
     x-extensible-enum:
       - PPT_STAZIONE_INT_PA_IRRAGGIUNGIBILE
       - PPT_STAZIONE_INT_PA_SERVIZIO_NONATTIVO
   PartyTimeoutFault:
-    description: TODO - mapped to 504
+    description: Fault codes for timeout errors, should be mapped to 504 HTTP status code.
     type: string
     x-extensible-enum:
       - PPT_STAZIONE_INT_PA_TIMEOUT

--- a/api-spec/api-pagopa-proxy.yaml
+++ b/api-spec/api-pagopa-proxy.yaml
@@ -30,7 +30,7 @@ paths:
           schema:
             $ref: "#/definitions/ProblemJson"
         '404':
-          description: Invalid input
+          description: Node cannot find the services needed to process this request in its configuration. This error is most likely to occur when submitting a non-existing RPT id.
           schema:
             $ref: "#/definitions/ValidationFaultPaymentProblemJson"
         '409':
@@ -80,7 +80,7 @@ paths:
           schema:
             $ref: "#/definitions/ProblemJson"
         '404':
-          description: Invalid input
+          description: Node cannot find the services needed to process this request in its configuration. This error is most likely to occur when submitting a non-existing RPT id.
           schema:
             $ref: "#/definitions/ValidationFaultPaymentProblemJson"
         '409':

--- a/api-spec/api-pagopa-proxy.yaml
+++ b/api-spec/api-pagopa-proxy.yaml
@@ -520,7 +520,18 @@ definitions:
       importoSpezzone:
         $ref: '#/definitions/ImportoEuroCents'
   PaymentFault:
-    description: Fault codes for the PagoPA Verifica and Attiva operations ( Deprecated )
+    description: |-
+      DEPRECATED. Fault codes for the PagoPA Verifica and Attiva operations.
+      Possible fault codes are:
+      - `PAYMENT_DUPLICATED`
+      - `INVALID_AMOUNT`
+      - `PAYMENT_ONGOING`
+      - `PAYMENT_EXPIRED`
+      - `PAYMENT_UNAVAILABLE`
+      - `PAYMENT_UNKNOWN`
+      - `DOMAIN_UNKNOWN`
+      - `PPT_MULTI_BENEFICIARIO`
+      - `GENERIC_ERROR`
     type: string
     x-extensible-enum:
       - PAYMENT_DUPLICATED
@@ -537,6 +548,11 @@ definitions:
       Fault codes for errors related to payment attempts that cause conflict with the current payment status,
       such as a duplicated payment attempt or a payment attempt made while another attempt is still being processed.
       Should be mapped to 409 HTTP status code.
+      Possible fault codes are:
+      - `PPT_PAGAMENTO_IN_CORSO`
+      - `PAA_PAGAMENTO_IN_CORSO`
+      - `PPT_PAGAMENTO_DUPLICATO`
+      - `PAA_PAGAMENTO_DUPLICATO`
     type: string
     x-extensible-enum:
       - PPT_PAGAMENTO_IN_CORSO
@@ -546,14 +562,34 @@ definitions:
   ValidationFault:
     description: |-
       Fault codes for errors related to well-formed requests to ECs not present inside Nodo, should be mapped to 404 HTTP status code.
-      Most of the time these are generated when users input a wrong fiscal code or notice number.
+      Most of the time these are generated when users input a wrong fiscal code or notice number. 
+      Possible fault codes are:
+      - `PPT_DOMINIO_SCONOSCIUTO`
+      - `PPT_INTERMEDIARIO_PA_SCONOSCIUTO`
+      - `PPT_STAZIONE_INT_PA_SCONOSCIUTA`
     type: string
     x-extensible-enum:
       - PPT_DOMINIO_SCONOSCIUTO
       - PPT_INTERMEDIARIO_PA_SCONOSCIUTO
       - PPT_STAZIONE_INT_PA_SCONOSCIUTA
   GatewayFault:
-    description: Fault codes for generic downstream services errors, should be mapped to 502 HTTP status code.
+    description: |-
+      Fault codes for generic downstream services errors, should be mapped to 502 HTTP status code.
+      Possible fault codes are:
+      - `GENERIC_ERROR`
+      - `PPT_SINTASSI_EXTRAXSD`
+      - `PPT_SINTASSI_XSD`
+      - `PPT_PSP_SCONOSCIUTO`
+      - `PPT_PSP_DISABILITATO`
+      - `PPT_INTERMEDIARIO_PSP_SCONOSCIUTO`
+      - `PPT_INTERMEDIARIO_PSP_DISABILITATO`
+      - `PPT_CANALE_SCONOSCIUTO`
+      - `PPT_CANALE_DISABILITATO`
+      - `PPT_AUTENTICAZIONE`
+      - `PPT_AUTORIZZAZIONE`
+      - `PPT_CODIFICA_PSP_SCONOSCIUTA`
+      - `PPT_SEMANTICA`
+      - `PPT_SYSTEM_ERROR`
     type: string
     x-extensible-enum:
       - GENERIC_ERROR
@@ -571,7 +607,15 @@ definitions:
       - PPT_SEMANTICA
       - PPT_SYSTEM_ERROR
   PartyConfigurationFault:
-    description: Fault codes for fatal errors from ECs, should be mapped to 503 HTTP status code.
+    description: |-
+      Fault codes for fatal errors from ECs, should be mapped to 503 HTTP status code.
+      Possible fault codes are:
+      - `PPT_DOMINIO_DISABILITATO`
+      - `PPT_INTERMEDIARIO_PA_DISABILITATO`
+      - `PPT_STAZIONE_INT_PA_DISABILITATA`
+      - `PPT_ERRORE_EMESSO_DA_PAA`
+      - `PPT_STAZIONE_INT_PA_ERRORE_RESPONSE`
+      - `PPT_IBAN_NON_CENSITO`
     type: string
     x-extensible-enum:
       - PPT_DOMINIO_DISABILITATO
@@ -581,7 +625,13 @@ definitions:
       - PPT_STAZIONE_INT_PA_ERRORE_RESPONSE
       - PPT_IBAN_NON_CENSITO
   PartyTimeoutFault:
-    description: Fault codes for timeout errors, should be mapped to 504 HTTP status code.
+    description: |-
+      Fault codes for timeout errors, should be mapped to 504 HTTP status code.
+      Possible fault codes are:
+      - `PPT_STAZIONE_INT_PA_TIMEOUT`
+      - `PPT_STAZIONE_INT_PA_IRRAGGIUNGIBILE`
+      - `PPT_STAZIONE_INT_PA_SERVIZIO_NONATTIVO`
+      - `GENERIC_ERROR`
     type: string
     x-extensible-enum:
       - PPT_STAZIONE_INT_PA_TIMEOUT
@@ -589,7 +639,120 @@ definitions:
       - PPT_STAZIONE_INT_PA_SERVIZIO_NONATTIVO
       - GENERIC_ERROR
   PaymentFaultV2:
-    description: Fault codes for the PagoPA/Controparte Verifica and Attiva operations
+    description: |-
+      This enumeration includes all possible fault codes for the PagoPA/Controparte Verifica ([`getPaymentInfo`](#/default/getPaymentInfo)) and Attiva ([`activatePayment`](#/default/activatePayment)) operations.
+      Please note that this enumeration is for documentation purposes only, and the API specification will use more precise subsets of this enumeration instead.
+      Possible fault codes are:
+      - `PPT_SYSTEM_ERROR`
+      - `PPT_AUTORIZZAZIONE`
+      - `PPT_AUTENTICAZIONE`
+      - `PPT_SINTASSI_XSD`
+      - `PPT_SINTASSI_EXTRAXSD`
+      - `PPT_SEMANTICA`
+      - `PPT_RPT_DUPLICATA`
+      - `PPT_RPT_SCONOSCIUTA`
+      - `PPT_RT_SCONOSCIUTA`
+      - `PPT_RT_NONDISPONIBILE`
+      - `PPT_SUPERAMENTOSOGLIA`
+      - `PPT_SEGREGAZIONE`
+      - `PPT_TIPOFIRMA_SCONOSCIUTO`
+      - `PPT_ERRORE_FORMATO_BUSTA_FIRMATA`
+      - `PPT_FIRMA_INDISPONIBILE`
+      - `PPT_ID_CARRELLO_DUPLICATO`
+      - `PPT_OPER_NON_STORNABILE`
+      - `PPT_OPER_NON_REVOCABILE`
+      - `PPT_WISP_TIMEOUT_RECUPERO_SCELTA`
+      - `PPT_WISP_SESSIONE_SCONOSCIUTA`
+      - `PPT_CANALE_ERRORE`
+      - `PPT_CODIFICA_PSP_SCONOSCIUTA`
+      - `PPT_PSP_SCONOSCIUTO`
+      - `PPT_PSP_DISABILITATO`
+      - `PPT_TIPO_VERSAMENTO_SCONOSCIUTO`
+      - `PPT_INTERMEDIARIO_PSP_SCONOSCIUTO`
+      - `PPT_INTERMEDIARIO_PSP_DISABILITATO`
+      - `PPT_CANALE_IRRAGGIUNGIBILE`
+      - `PPT_CANALE_SERVIZIO_NONATTIVO`
+      - `PPT_CANALE_TIMEOUT`
+      - `PPT_CANALE_NONRISOLVIBILE`
+      - `PPT_CANALE_INDISPONIBILE`
+      - `PPT_CANALE_SCONOSCIUTO`
+      - `PPT_CANALE_DISABILITATO`
+      - `PPT_CANALE_ERR_PARAM_PAG_IMM`
+      - `PPT_CANALE_ERRORE_RESPONSE`
+      - `PPT_RT_DUPLICATA`
+      - `PPT_ISCRIZIONE_NON_PRESENTE`
+      - `PPT_ULTERIORE_ISCRIZIONE`
+      - `PPT_PDD_IRRAGGIUNGIBILE`
+      - `PPT_ERRORE_EMESSO_DA_PAA`
+      - `PPT_DOMINIO_SCONOSCIUTO`
+      - `PPT_DOMINIO_DISABILITATO`
+      - `PPT_INTERMEDIARIO_PA_SCONOSCIUTO`
+      - `PPT_INTERMEDIARIO_PA_DISABILITATO`
+      - `PPT_STAZIONE_INT_PA_IRRAGGIUNGIBILE`
+      - `PPT_STAZIONE_INT_PA_SERVIZIO_NONATTIVO`
+      - `PPT_STAZIONE_INT_PA_ERRORE_RESPONSE`
+      - `PPT_STAZIONE_INT_PA_TIMEOUT`
+      - `PPT_STAZIONE_INT_PA_NONRISOLVIBILE`
+      - `PPT_STAZIONE_INT_PA_INDISPONIBILE`
+      - `PPT_STAZIONE_INT_PA_SCONOSCIUTA`
+      - `PPT_STAZIONE_INT_PA_DISABILITATA`
+      - `PPT_ID_FLUSSO_SCONOSCIUTO`
+      - `PAA_ID_DOMINIO_ERRATO`
+      - `PAA_ID_INTERMEDIARIO_ERRATO`
+      - `PAA_STAZIONE_INT_ERRATA`
+      - `PAA_RPT_SCONOSCIUTA`
+      - `PAA_RT_DUPLICATA`
+      - `PAA_TIPOFIRMA_SCONOSCIUTO`
+      - `PAA_ERRORE_FORMATO_BUSTA_FIRMATA`
+      - `PAA_FIRMA_INDISPONIBILE`
+      - `PAA_FIRMA_ERRATA`
+      - `PAA_PAGAMENTO_SCONOSCIUTO`
+      - `PAA_PAGAMENTO_DUPLICATO`
+      - `PAA_PAGAMENTO_IN_CORSO`
+      - `PAA_PAGAMENTO_ANNULLATO`
+      - `PAA_PAGAMENTO_SCADUTO`
+      - `PAA_SINTASSI_XSD`
+      - `PAA_SINTASSI_EXTRAXSD`
+      - `PAA_SEMANTICA`
+      - `PAA_ATTIVA_RPT_IMPORTO_NON_VALIDO`
+      - `PAA_SYSTEM_ERROR`
+      - `CANALE_SINTASSI_XSD`
+      - `CANALE_SINTASSI_EXTRAXSD`
+      - `CANALE_SEMANTICA`
+      - `CANALE_RPT_DUPLICATA`
+      - `CANALE_RPT_SCONOSCIUTA`
+      - `CANALE_RPT_RIFIUTATA`
+      - `CANALE_RT_SCONOSCIUTA`
+      - `CANALE_RT_NON_DISPONIBILE`
+      - `CANALE_INDISPONIBILE`
+      - `CANALE_RICHIEDENTE_ERRATO`
+      - `CANALE_SYSTEM_ERROR`
+      - `PPT_LOCAL_ERROR_PROTOCOLLO`
+      - `PPT_LOCAL_ERROR_EXTRAXSD`
+      - `PPT_LOCAL_ERROR_FSM`
+      - `PPT_RT_SEGNO_DISCORDE`
+      - `CANALE_FIRMA_SCONOSCIUTA`
+      - `CANALE_BUSTA_ERRATA`
+      - `CANALE_NEGA_CONTABILIZZAZIONE`
+      - `CANALE_CARRELLO_DUPLICATO_KO`
+      - `CANALE_CARRELLO_DUPLICATO_UNKNOWN`
+      - `CANALE_CARRELLO_DUPLICATO_OK`
+      - `OGGETTO_DISABILITATO`
+      - `PPT_IBAN_NON_CENSITO`
+      - `PPT_RT_IN_GESTIONE`
+      - `CANALE_CONVENZIONE_NON_VALIDA`
+      - `PAA_CONVENZIONE_NON_VALIDA`
+      - `PPT_IMPORTO_ERRATO`
+      - `PPT_TOKEN_SCONOSCIUTO`
+      - `PPT_TOKEN_SCADUTO`
+      - `PPT_POSIZIONE_SCONOSCIUTA`
+      - `PPT_DATI_POSIZIONE_GIA_CONOSCIUTI`
+      - `PPT_ESITO_GIA_ACQUISITO`
+      - `PPT_PAGAMENTO_IN_CORSO`
+      - `PPT_PAGAMENTO_DUPLICATO`
+      - `PPT_MULTI_BENEFICIARIO`
+      - `PPT_ERRORE`
+      - `GENERIC_ERROR`
     type: string
     x-extensible-enum:
       - PPT_SYSTEM_ERROR

--- a/api-spec/api-pagopa-proxy.yaml
+++ b/api-spec/api-pagopa-proxy.yaml
@@ -548,6 +548,7 @@ definitions:
       Fault codes for errors related to payment attempts that cause conflict with the current payment status,
       such as a duplicated payment attempt or a payment attempt made while another attempt is still being processed.
       Should be mapped to 409 HTTP status code.
+      For further information visit https://docs.pagopa.it/gestionedeglierrori/struttura-degli-errori/fault-code.
       Possible fault codes are:
       - `PPT_PAGAMENTO_IN_CORSO`
       - `PAA_PAGAMENTO_IN_CORSO`
@@ -562,7 +563,8 @@ definitions:
   ValidationFault:
     description: |-
       Fault codes for errors related to well-formed requests to ECs not present inside Nodo, should be mapped to 404 HTTP status code.
-      Most of the time these are generated when users input a wrong fiscal code or notice number. 
+      Most of the time these are generated when users input a wrong fiscal code or notice number.
+      For further information visit https://docs.pagopa.it/gestionedeglierrori/struttura-degli-errori/fault-code.
       Possible fault codes are:
       - `PPT_DOMINIO_SCONOSCIUTO`
       - `PPT_INTERMEDIARIO_PA_SCONOSCIUTO`
@@ -575,6 +577,7 @@ definitions:
   GatewayFault:
     description: |-
       Fault codes for generic downstream services errors, should be mapped to 502 HTTP status code.
+      For further information visit https://docs.pagopa.it/gestionedeglierrori/struttura-degli-errori/fault-code.
       Possible fault codes are:
       - `GENERIC_ERROR`
       - `PPT_SINTASSI_EXTRAXSD`
@@ -609,6 +612,7 @@ definitions:
   PartyConfigurationFault:
     description: |-
       Fault codes for fatal errors from ECs, should be mapped to 503 HTTP status code.
+      For further information visit https://docs.pagopa.it/gestionedeglierrori/struttura-degli-errori/fault-code.
       Possible fault codes are:
       - `PPT_DOMINIO_DISABILITATO`
       - `PPT_INTERMEDIARIO_PA_DISABILITATO`
@@ -627,6 +631,7 @@ definitions:
   PartyTimeoutFault:
     description: |-
       Fault codes for timeout errors, should be mapped to 504 HTTP status code.
+      For further information visit https://docs.pagopa.it/gestionedeglierrori/struttura-degli-errori/fault-code.
       Possible fault codes are:
       - `PPT_STAZIONE_INT_PA_TIMEOUT`
       - `PPT_STAZIONE_INT_PA_IRRAGGIUNGIBILE`
@@ -642,6 +647,7 @@ definitions:
     description: |-
       This enumeration includes all possible fault codes for the PagoPA/Controparte Verifica ([`getPaymentInfo`](#/default/getPaymentInfo)) and Attiva ([`activatePayment`](#/default/activatePayment)) operations.
       Please note that this enumeration is for documentation purposes only, and the API specification will use more precise subsets of this enumeration instead.
+      For further information visit https://docs.pagopa.it/gestionedeglierrori/struttura-degli-errori/fault-code.
       Possible fault codes are:
       - `PPT_SYSTEM_ERROR`
       - `PPT_AUTORIZZAZIONE`

--- a/api-spec/api-pagopa-proxy.yaml
+++ b/api-spec/api-pagopa-proxy.yaml
@@ -33,6 +33,10 @@ paths:
           description: Invalid input
           schema:
             $ref: "#/definitions/ValidationFaultPaymentProblemJson"
+        '409':
+          description: Conflict on payment status
+          schema:
+            $ref: "#/definitions/PaymentStatusFaultPaymentProblemJson"
         "502":
           description: PagoPA services are not available or request is rejected by PagoPa
           schema:
@@ -79,6 +83,10 @@ paths:
           description: Invalid input
           schema:
             $ref: "#/definitions/ValidationFaultPaymentProblemJson"
+        '409':
+          description: Conflict on payment status
+          schema:
+            $ref: "#/definitions/PaymentStatusFaultPaymentProblemJson"
         "502":
           description: PagoPA services are not available or request is rejected by PagoPa
           schema:
@@ -192,6 +200,46 @@ definitions:
         $ref: "#/definitions/PaymentFault"
       detail_v2:
         $ref: "#/definitions/ValidationFault"
+      instance:
+        type: string
+        format: uri
+        description: |-
+          An absolute URI that identifies the specific occurrence of the problem.
+          It may or may not yield further information if dereferenced.
+    required:
+      - detail
+      - detail_v2
+  PaymentStatusFaultPaymentProblemJson:
+    description: |-
+      A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.
+      Possible values of `detail_v2` are limited to faults pertaining to Nodo errors related to payment status conflicts.
+    type: object
+    properties:
+      type:
+        type: string
+        format: uri
+        description: |-
+          An absolute URI that identifies the problem type. When dereferenced,
+          it SHOULD provide human-readable documentation for the problem type
+          (e.g., using HTML).
+        default: about:blank
+        example: https://example.com/problem/constraint-violation
+      title:
+        type: string
+        description: |-
+          A short, summary of the problem type. Written in english and readable
+          for engineers (usually not suited for non technical stakeholders and
+          not localized); example: Service Unavailable
+      status:
+        type: integer
+        format: int32
+        minimum: 100
+        maximum: 600
+        exclusiveMaximum: true
+      detail:
+        $ref: "#/definitions/PaymentFault"
+      detail_v2:
+        $ref: "#/definitions/PaymentStatusFault"
       instance:
         type: string
         format: uri
@@ -484,6 +532,17 @@ definitions:
       - DOMAIN_UNKNOWN
       - PPT_MULTI_BENEFICIARIO
       - GENERIC_ERROR
+  PaymentStatusFault:
+    description: |-
+      Fault codes for errors related to payment attempts that cause conflict with the current payment status,
+      such as a duplicated payment attempt or a payment attempt made while another attempt is still being processed.
+      Should be mapped to 409 HTTP status code.
+    type: string
+    x-extensible-enum:
+      - PPT_PAGAMENTO_IN_CORSO
+      - PAA_PAGAMENTO_IN_CORSO
+      - PPT_PAGAMENTO_DUPLICATO
+      - PAA_PAGAMENTO_DUPLICATO
   ValidationFault:
     description: |-
       Fault codes for errors related to well-formed requests to ECs not present inside Nodo, should be mapped to 404 HTTP status code.
@@ -498,10 +557,6 @@ definitions:
     type: string
     x-extensible-enum:
       - GENERIC_ERROR
-      - PPT_PAGAMENTO_IN_CORSO
-      - PAA_PAGAMENTO_IN_CORSO
-      - PPT_PAGAMENTO_DUPLICATO
-      - PAA_PAGAMENTO_DUPLICATO
       - PPT_SINTASSI_EXTRAXSD
       - PPT_SINTASSI_XSD
       - PPT_PSP_SCONOSCIUTO

--- a/api-spec/api-pagopa-proxy.yaml
+++ b/api-spec/api-pagopa-proxy.yaml
@@ -537,6 +537,7 @@ definitions:
     x-extensible-enum:
       - GENERIC_ERROR
       - PPT_PAGAMENTO_IN_CORSO
+      - PAA_PAGAMENTO_IN_CORSO
       - PPT_PAGAMENTO_DUPLICATO
       - PPT_SINTASSI_EXTRAXSD
       - PPT_SINTASSI_XSD

--- a/api-spec/api-pagopa-proxy.yaml
+++ b/api-spec/api-pagopa-proxy.yaml
@@ -25,6 +25,10 @@ paths:
             application/json:
               importoSingoloVersamento: 200,
               codiceContestoPagamento: 'ABC123'
+        '400':
+          description: Formally invalid input
+          schema:
+            $ref: "#/definitions/ProblemJson"
         '404':
           description: Invalid input
           schema:
@@ -67,6 +71,10 @@ paths:
           examples:
             application/json:
               importoSingoloVersamento: 200
+        '400':
+          description: Formally invalid input
+          schema:
+            $ref: "#/definitions/ProblemJson"
         '404':
           description: Invalid input
           schema:

--- a/api-spec/api-pagopa-proxy.yaml
+++ b/api-spec/api-pagopa-proxy.yaml
@@ -472,6 +472,7 @@ definitions:
     description: TODO - mapped to 502
     type: string
     x-extensible-enum:
+      - GENERIC_ERROR
       - PPT_SINTASSI_EXTRAXSD
       - PPT_SINTASSI_XSD
       - PPT_PSP_SCONOSCIUTO

--- a/api-spec/api-pagopa-proxy.yaml
+++ b/api-spec/api-pagopa-proxy.yaml
@@ -41,10 +41,6 @@ paths:
           description: Timeout from PagoPA services
           schema:
             $ref: "#/definitions/PartyTimeoutFaultPaymentProblemJson"
-        '598':
-          description: Service connection error while connecting to PagoPA services
-          schema:
-            $ref: "#/definitions/PartyConnectionFaultPaymentProblemJson"
   '/payment-activations':
     x-swagger-router-controller: PaymentController
     post:
@@ -87,10 +83,6 @@ paths:
           description: Timeout from PagoPA services
           schema:
             $ref: "#/definitions/PartyTimeoutFaultPaymentProblemJson"
-        '598':
-          description: Service connection error while connecting to PagoPA services
-          schema:
-            $ref: "#/definitions/PartyConnectionFaultPaymentProblemJson"
   '/payment-activations/{codice_contesto_pagamento}':
     x-swagger-router-controller: PaymentController
     get:
@@ -272,46 +264,6 @@ definitions:
         $ref: "#/definitions/PaymentFault"
       detail_v2:
         $ref: "#/definitions/PartyConfigurationFault"
-      instance:
-        type: string
-        format: uri
-        description: |-
-          An absolute URI that identifies the specific occurrence of the problem.
-          It may or may not yield further information if dereferenced.
-    required:
-      - detail
-      - detail_v2
-  PartyConnectionFaultPaymentProblemJson:
-    description: |-
-      A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.
-      Possible values of `detail_v2` are limited to faults pertaining to connection errors towards ECs.
-    type: object
-    properties:
-      type:
-        type: string
-        format: uri
-        description: |-
-          An absolute URI that identifies the problem type. When dereferenced,
-          it SHOULD provide human-readable documentation for the problem type
-          (e.g., using HTML).
-        default: about:blank
-        example: https://example.com/problem/constraint-violation
-      title:
-        type: string
-        description: |-
-          A short, summary of the problem type. Written in english and readable
-          for engineers (usually not suited for non technical stakeholders and
-          not localized); example: Service Unavailable
-      status:
-        type: integer
-        format: int32
-        minimum: 100
-        maximum: 600
-        exclusiveMaximum: true
-      detail:
-        $ref: "#/definitions/PaymentFault"
-      detail_v2:
-        $ref: "#/definitions/PartyConnectionFault"
       instance:
         type: string
         format: uri
@@ -565,17 +517,13 @@ definitions:
       - PPT_ERRORE_EMESSO_DA_PAA
       - PPT_STAZIONE_INT_PA_ERRORE_RESPONSE
       - PPT_IBAN_NON_CENSITO
-  PartyConnectionFault:
-    description: Fault codes for connection errors to ECs, should be mapped to 598 HTTP status code.
-    type: string
-    x-extensible-enum:
-      - PPT_STAZIONE_INT_PA_IRRAGGIUNGIBILE
-      - PPT_STAZIONE_INT_PA_SERVIZIO_NONATTIVO
   PartyTimeoutFault:
     description: Fault codes for timeout errors, should be mapped to 504 HTTP status code.
     type: string
     x-extensible-enum:
       - PPT_STAZIONE_INT_PA_TIMEOUT
+      - PPT_STAZIONE_INT_PA_IRRAGGIUNGIBILE
+      - PPT_STAZIONE_INT_PA_SERVIZIO_NONATTIVO
       - GENERIC_ERROR
   PaymentFaultV2:
     description: Fault codes for the PagoPA/Controparte Verifica and Attiva operations

--- a/api-spec/api-pagopa-proxy.yaml
+++ b/api-spec/api-pagopa-proxy.yaml
@@ -244,7 +244,7 @@ definitions:
   PartyConfigurationFaultPaymentProblemJson:
     description: |-
       A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.
-      Possible values of `detail_v2` are limited to faults pertaining to EC non-fatal errors.
+      Possible values of `detail_v2` are limited to faults pertaining to EC fatal errors.
     type: object
     properties:
       type:
@@ -282,7 +282,9 @@ definitions:
       - detail
       - detail_v2
   PartyConnectionFaultPaymentProblemJson:
-    description: TODO - A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations
+    description: |-
+      A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.
+      Possible values of `detail_v2` are limited to faults pertaining to connection errors towards ECs.
     type: object
     properties:
       type:
@@ -320,7 +322,9 @@ definitions:
       - detail
       - detail_v2
   PartyTimeoutFaultPaymentProblemJson:
-    description: TODO - A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations
+    description: |-
+      A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.
+      Possible values of `detail_v2` are limited to faults pertaining to EC timeouts.
     type: object
     properties:
       type:
@@ -521,14 +525,14 @@ definitions:
       - PPT_MULTI_BENEFICIARIO
       - GENERIC_ERROR
   ValidationFault:
-    description: TODO - mapped to 400
+    description: Fault codes for validation/syntactical errors, should be mapped to 400 HTTP status code.
     type: string
     x-extensible-enum:
       - PPT_DOMINIO_SCONOSCIUTO
       - PPT_INTERMEDIARIO_PA_SCONOSCIUTO
       - PPT_STAZIONE_INT_PA_SCONOSCIUTA
   GatewayFault:
-    description: TODO - mapped to 502
+    description: Fault codes for generic downstream services errors, should be mapped to 502 HTTP status code.
     type: string
     x-extensible-enum:
       - GENERIC_ERROR
@@ -548,7 +552,7 @@ definitions:
       - PPT_SEMANTICA
       - PPT_SYSTEM_ERROR
   PartyConfigurationFault:
-    description: TODO - mapped to 503
+    description: Fault codes for , should be mapped to 503 HTTP status code.
     type: string
     x-extensible-enum:
       - PPT_DOMINIO_DISABILITATO
@@ -569,7 +573,6 @@ definitions:
     x-extensible-enum:
       - PPT_STAZIONE_INT_PA_TIMEOUT
       - GENERIC_ERROR
-
   PaymentFaultV2:
     description: Fault codes for the PagoPA/Controparte Verifica and Attiva operations
     type: string

--- a/api-spec/api-pagopa-proxy.yaml
+++ b/api-spec/api-pagopa-proxy.yaml
@@ -25,7 +25,7 @@ paths:
             application/json:
               importoSingoloVersamento: 200,
               codiceContestoPagamento: 'ABC123'
-        '400':
+        '404':
           description: Invalid input
           schema:
             $ref: "#/definitions/ValidationFaultPaymentProblemJson"
@@ -71,7 +71,7 @@ paths:
           examples:
             application/json:
               importoSingoloVersamento: 200
-        '400':
+        '404':
           description: Invalid input
           schema:
             $ref: "#/definitions/ValidationFaultPaymentProblemJson"
@@ -111,11 +111,11 @@ paths:
         '400':
           description: Invalid input
           schema:
-            $ref: "#/definitions/ValidationFaultPaymentProblemJson"
+            $ref: "#/definitions/ProblemJson"
         '404':
           description: Activation status not found
           schema:
-            $ref: "#/definitions/ProblemJson"
+            $ref: "#/definitions/ValidationFaultPaymentProblemJson"
         "502":
           description: PagoPA services are not available or request is rejected by PagoPa
           schema:
@@ -525,7 +525,9 @@ definitions:
       - PPT_MULTI_BENEFICIARIO
       - GENERIC_ERROR
   ValidationFault:
-    description: Fault codes for validation/syntactical errors, should be mapped to 400 HTTP status code.
+    description: |-
+      Fault codes for errors related to well-formed requests to ECs not present inside Nodo, should be mapped to 404 HTTP status code.
+      Most of the time these are generated when users input a wrong fiscal code or notice number.
     type: string
     x-extensible-enum:
       - PPT_DOMINIO_SCONOSCIUTO
@@ -539,6 +541,7 @@ definitions:
       - PPT_PAGAMENTO_IN_CORSO
       - PAA_PAGAMENTO_IN_CORSO
       - PPT_PAGAMENTO_DUPLICATO
+      - PAA_PAGAMENTO_DUPLICATO
       - PPT_SINTASSI_EXTRAXSD
       - PPT_SINTASSI_XSD
       - PPT_PSP_SCONOSCIUTO

--- a/src/__integration__/PaymentController.test.ts
+++ b/src/__integration__/PaymentController.test.ts
@@ -303,7 +303,7 @@ describe("checkPaymentToPagoPa", () => {
       verifyPaymentNoticePaClientNm3
     )(req);
 
-    expect(errorOrPaymentCheckResponse.kind).toBe("IResponseErrorValidation");
+    expect(errorOrPaymentCheckResponse.kind).toBe("IResponseValidationError");
   });
 
   it("should return error invalid client header", async () => {
@@ -334,7 +334,7 @@ describe("checkPaymentToPagoPa", () => {
       verifyPaymentNoticePaClientNm3
     )(req);
   
-    expect(errorOrPaymentCheckResponse.kind).toBe("IResponseErrorValidation");
+    expect(errorOrPaymentCheckResponse.kind).toBe("IResponseValidationError");
   });
 
   it("should return generic error due to invalid nodo response", async () => {
@@ -364,7 +364,7 @@ describe("checkPaymentToPagoPa", () => {
       verificaRPTPagoPaClient,
       verifyPaymentNoticePaClientNm3
     )(req);
-    expect(errorOrPaymentCheckResponse.kind).toBe("IResponseErrorInternal");
+    expect(errorOrPaymentCheckResponse.kind).toBe("IResponseGatewayError");
   });
 
   it("should return timeout error due to nodo timeout", async () => {
@@ -416,7 +416,7 @@ describe("checkPaymentToPagoPa", () => {
     const req = mockReq();
   
     // tslint:disable-next-line:no-object-mutation
-    req.params = { rpt_id_from_string: aRptIdStringForKoWithoutDeatilsResponse };;
+    req.params = { rpt_id_from_string: aRptIdStringForKoWithoutDeatilsResponse };
     req.headers = { "X-Client-Id": TEST_CLIENT_ID };
   
     const errorOrPaymentCheckResponse = await getPaymentInfo(
@@ -424,7 +424,7 @@ describe("checkPaymentToPagoPa", () => {
       verificaRPTPagoPaClient,
       verifyPaymentNoticePaClientNm3
     )(req);
-    expect(errorOrPaymentCheckResponse.kind).toBe("IResponseErrorInternal");
+    expect(errorOrPaymentCheckResponse.kind).toBe("IResponseGatewayError");
   });
 
   it("should return detail error due to nodo PAA_PAGAMENTO_IN_CORSO", async () => {
@@ -454,7 +454,7 @@ describe("checkPaymentToPagoPa", () => {
       verificaRPTPagoPaClient,
       verifyPaymentNoticePaClientNm3
     )(req);
-    expect(errorOrPaymentCheckResponse.kind).toBe("IResponseErrorInternal");
+    expect(errorOrPaymentCheckResponse.kind).toBe("IResponseGatewayError");
   });
 
   it("should return right response for PPT_MULTI_BENEFICIARIO", async () => {
@@ -514,7 +514,7 @@ describe("checkPaymentToPagoPa", () => {
       verificaRPTPagoPaClient,
       verifyPaymentNoticePaClientNm3
     )(req);
-    expect(errorOrPaymentCheckResponse.kind).toBe("IResponseErrorInternal");
+    expect(errorOrPaymentCheckResponse.kind).toBe("IResponseGatewayError");
   
   
   });
@@ -575,7 +575,7 @@ describe("checkPaymentToPagoPa", () => {
       verificaRPTPagoPaClient,
       verifyPaymentNoticePaClientNm3
     )(req);
-    expect(errorOrPaymentCheckResponse.kind).toBe("IResponseErrorInternal");
+    expect(errorOrPaymentCheckResponse.kind).toBe("IResponseGatewayError");
   });
 
   it("should return error with invalid nodo configuration", async () => {
@@ -605,7 +605,7 @@ describe("checkPaymentToPagoPa", () => {
       verificaRPTPagoPaClient,
       verifyPaymentNoticePaClientNm3
     )(req);
-    expect(errorOrPaymentCheckResponse.kind).toBe("IResponseErrorValidation");
+    expect(errorOrPaymentCheckResponse.kind).toBe("IResponseValidationError");
   });
 });
 
@@ -740,7 +740,7 @@ describe("activatePaymentToPagoPa", () => {
     )(req);
 
     expect(errorOrPaymentActivationResponse.kind).toBe(
-      "IResponseErrorValidation"
+      "IResponseValidationError"
     );
   });
 
@@ -775,7 +775,7 @@ describe("activatePaymentToPagoPa", () => {
     )(req);
 
     expect(errorOrPaymentActivationResponse.kind).toBe(
-      "IResponseErrorValidation"
+      "IResponseValidationError"
     );
   });
 
@@ -807,7 +807,7 @@ describe("activatePaymentToPagoPa", () => {
       0
     )(req);
   
-    expect(errorOrPaymentActivationResponse.kind).toBe("IResponseErrorInternal");
+    expect(errorOrPaymentActivationResponse.kind).toBe("IResponseGatewayError");
   });
 
   it("should return timeout error due to nodo timeout", async () => {
@@ -869,7 +869,7 @@ describe("activatePaymentToPagoPa", () => {
       0
     )(req);
   
-    expect(errorOrPaymentActivationResponse.kind).toBe("IResponseErrorInternal");
+    expect(errorOrPaymentActivationResponse.kind).toBe("IResponseGatewayError");
   });
 
   it("should return detail error due to nodo PAA_PAGAMENTO_IN_CORSO", async () => {
@@ -900,7 +900,7 @@ describe("activatePaymentToPagoPa", () => {
       0
     )(req);
   
-    expect(errorOrPaymentActivationResponse.kind).toBe("IResponseErrorInternal");
+    expect(errorOrPaymentActivationResponse.kind).toBe("IResponseGatewayError");
   });
 
   it("should return right response for PPT_MULTI_BENEFICIARIO", async () => {
@@ -977,7 +977,7 @@ describe("activatePaymentToPagoPa", () => {
   
     expect(aMockedRedisClient.connected).toBeTruthy();
 
-    expect(errorOrPaymentActivationResponse.kind).toBe("IResponseErrorValidation");
+    expect(errorOrPaymentActivationResponse.kind).toBe("IResponseValidationError");
 
   });
 
@@ -1040,7 +1040,7 @@ describe("activatePaymentToPagoPa", () => {
       10000
     )(req);
   
-    expect(errorOrPaymentActivationResponse.kind).toBe("IResponseErrorInternal");
+    expect(errorOrPaymentActivationResponse.kind).toBe("IResponseGatewayError");
   });
 
   it("should return invalid response for PPT_MULTI_BENEFICIARIO", async () => {
@@ -1071,7 +1071,7 @@ describe("activatePaymentToPagoPa", () => {
       10000
     )(req);
   
-    expect(errorOrPaymentActivationResponse.kind).toBe("IResponseErrorInternal");
+    expect(errorOrPaymentActivationResponse.kind).toBe("IResponseGatewayError");
   });
 });
 
@@ -1125,7 +1125,7 @@ describe("setActivationStatus and getActivationStatus", () => {
       aMockedRedisClient
     )(req);
 
-    expect(errorOrPaymentActivationGet.kind).toBe("IResponseErrorInternal");
+    expect(errorOrPaymentActivationGet.kind).toBe("IResponseGatewayError");
     
   });
 });

--- a/src/__integration__/PaymentController.test.ts
+++ b/src/__integration__/PaymentController.test.ts
@@ -303,7 +303,7 @@ describe("checkPaymentToPagoPa", () => {
       verifyPaymentNoticePaClientNm3
     )(req);
 
-    expect(errorOrPaymentCheckResponse.kind).toBe("IResponseValidationError");
+    expect(errorOrPaymentCheckResponse.kind).toBe("IResponseErrorValidation");
   });
 
   it("should return error invalid client header", async () => {
@@ -334,7 +334,7 @@ describe("checkPaymentToPagoPa", () => {
       verifyPaymentNoticePaClientNm3
     )(req);
   
-    expect(errorOrPaymentCheckResponse.kind).toBe("IResponseValidationError");
+    expect(errorOrPaymentCheckResponse.kind).toBe("IResponseErrorValidation");
   });
 
   it("should return generic error due to invalid nodo response", async () => {
@@ -454,7 +454,7 @@ describe("checkPaymentToPagoPa", () => {
       verificaRPTPagoPaClient,
       verifyPaymentNoticePaClientNm3
     )(req);
-    expect(errorOrPaymentCheckResponse.kind).toBe("IResponseGatewayError");
+    expect(errorOrPaymentCheckResponse.kind).toBe("IResponsePaymentStatusFaultError");
   });
 
   it("should return right response for PPT_MULTI_BENEFICIARIO", async () => {
@@ -575,7 +575,7 @@ describe("checkPaymentToPagoPa", () => {
       verificaRPTPagoPaClient,
       verifyPaymentNoticePaClientNm3
     )(req);
-    expect(errorOrPaymentCheckResponse.kind).toBe("IResponseGatewayError");
+    expect(errorOrPaymentCheckResponse.kind).toBe("IResponsePaymentStatusFaultError");
   });
 
   it("should return error with invalid nodo configuration", async () => {
@@ -605,7 +605,7 @@ describe("checkPaymentToPagoPa", () => {
       verificaRPTPagoPaClient,
       verifyPaymentNoticePaClientNm3
     )(req);
-    expect(errorOrPaymentCheckResponse.kind).toBe("IResponseValidationError");
+    expect(errorOrPaymentCheckResponse.kind).toBe("IResponseErrorValidation");
   });
 });
 
@@ -740,7 +740,7 @@ describe("activatePaymentToPagoPa", () => {
     )(req);
 
     expect(errorOrPaymentActivationResponse.kind).toBe(
-      "IResponseValidationError"
+      "IResponseErrorValidation"
     );
   });
 
@@ -775,7 +775,7 @@ describe("activatePaymentToPagoPa", () => {
     )(req);
 
     expect(errorOrPaymentActivationResponse.kind).toBe(
-      "IResponseValidationError"
+      "IResponseErrorValidation"
     );
   });
 
@@ -900,7 +900,7 @@ describe("activatePaymentToPagoPa", () => {
       0
     )(req);
   
-    expect(errorOrPaymentActivationResponse.kind).toBe("IResponseGatewayError");
+    expect(errorOrPaymentActivationResponse.kind).toBe("IResponsePaymentStatusFaultError");
   });
 
   it("should return right response for PPT_MULTI_BENEFICIARIO", async () => {
@@ -977,7 +977,7 @@ describe("activatePaymentToPagoPa", () => {
   
     expect(aMockedRedisClient.connected).toBeTruthy();
 
-    expect(errorOrPaymentActivationResponse.kind).toBe("IResponseValidationError");
+    expect(errorOrPaymentActivationResponse.kind).toBe("IResponseErrorValidation");
 
   });
 
@@ -1040,7 +1040,7 @@ describe("activatePaymentToPagoPa", () => {
       10000
     )(req);
   
-    expect(errorOrPaymentActivationResponse.kind).toBe("IResponseGatewayError");
+    expect(errorOrPaymentActivationResponse.kind).toBe("IResponsePaymentStatusFaultError");
   });
 
   it("should return invalid response for PPT_MULTI_BENEFICIARIO", async () => {

--- a/src/controllers/restful/PaymentController.ts
+++ b/src/controllers/restful/PaymentController.ts
@@ -220,7 +220,10 @@ AsControllerFunction<GetPaymentInfoT> = (
           rptId: params.rpt_id_from_string
         }
       });
-      return ResponseGatewayTimeout();
+      return ResponsePaymentError(
+        PaymentFaultEnum.GENERIC_ERROR,
+        GatewayFaultEnum.GENERIC_ERROR
+      );
     }
 
     if (responseError.toString() !== PaymentFaultEnum.PPT_MULTI_BENEFICIARIO) {

--- a/src/controllers/restful/PaymentController.ts
+++ b/src/controllers/restful/PaymentController.ts
@@ -62,7 +62,7 @@ import {
   AsControllerFunction,
   AsControllerResponseType,
   GeneralRptId,
-  IResponsePartyConfigurationError,
+  IResponseValidationError,
   ResponseGatewayTimeout,
   ResponsePaymentError
 } from "../../utils/types";
@@ -76,7 +76,7 @@ import { GatewayFaultEnum } from "../../../generated/api/GatewayFault";
 
 const headerValidationErrorHandler: (
   e: ReadonlyArray<t.ValidationError>
-) => Promise<IResponsePartyConfigurationError> = async e =>
+) => Promise<IResponseValidationError> = async e =>
   ResponseErrorValidation(
     "Invalid X-Client-Id",
     e.map(err => err.message).join("\n")

--- a/src/controllers/restful/PaymentController.ts
+++ b/src/controllers/restful/PaymentController.ts
@@ -10,10 +10,7 @@ import * as O from "fp-ts/lib/Option";
 import * as t from "io-ts";
 import { PathReporter } from "io-ts/lib/PathReporter";
 import { TypeofApiResponse } from "@pagopa/ts-commons/lib/requests";
-import {
-  ResponseErrorNotFound,
-  ResponseSuccessJson
-} from "@pagopa/ts-commons/lib/responses";
+import { ResponseSuccessJson } from "@pagopa/ts-commons/lib/responses";
 import * as redis from "redis";
 import * as uuid from "uuid";
 
@@ -731,7 +728,7 @@ const getGetActivationStatusController: (
   const maybeIdPayment = maybeIdPaymentOrError.right;
 
   if (O.isNone(maybeIdPayment)) {
-    return ResponseErrorNotFound("Not found", "getActivationStatus");
+    return ResponseErrorValidation("Not found", "getActivationStatus");
   }
 
   const idPayment = maybeIdPayment.value;

--- a/src/controllers/restful/PaymentController.ts
+++ b/src/controllers/restful/PaymentController.ts
@@ -10,7 +10,12 @@ import * as O from "fp-ts/lib/Option";
 import * as t from "io-ts";
 import { PathReporter } from "io-ts/lib/PathReporter";
 import { TypeofApiResponse } from "@pagopa/ts-commons/lib/requests";
-import { ResponseSuccessJson } from "@pagopa/ts-commons/lib/responses";
+import {
+  IResponseErrorValidation,
+  ResponseErrorFromValidationErrors,
+  ResponseErrorValidation,
+  ResponseSuccessJson
+} from "@pagopa/ts-commons/lib/responses";
 import * as redis from "redis";
 import * as uuid from "uuid";
 
@@ -59,21 +64,16 @@ import {
   AsControllerFunction,
   AsControllerResponseType,
   GeneralRptId,
-  IResponseValidationError,
   ResponseGatewayTimeout,
   ResponsePaymentError
 } from "../../utils/types";
 import { RptId, RptIdFromString } from "../../utils/pagopa";
-import {
-  ResponseErrorFromValidationErrors,
-  ResponseErrorValidation,
-  responseFromPaymentFault
-} from "../../utils/responses";
+import { responseFromPaymentFault } from "../../utils/responses";
 import { GatewayFaultEnum } from "../../../generated/api/GatewayFault";
 
 const headerValidationErrorHandler: (
   e: ReadonlyArray<t.ValidationError>
-) => Promise<IResponseValidationError> = async e =>
+) => Promise<IResponseErrorValidation> = async e =>
   ResponseErrorValidation(
     "Invalid X-Client-Id",
     e.map(err => err.message).join("\n")

--- a/src/controllers/restful/PaymentController.ts
+++ b/src/controllers/restful/PaymentController.ts
@@ -12,10 +12,8 @@ import { PathReporter } from "io-ts/lib/PathReporter";
 import { TypeofApiResponse } from "@pagopa/ts-commons/lib/requests";
 import {
   IResponseErrorValidation,
-  ResponseErrorFromValidationErrors,
   ResponseErrorInternal,
   ResponseErrorNotFound,
-  ResponseErrorValidation,
   ResponseSuccessJson
 } from "@pagopa/ts-commons/lib/responses";
 import * as redis from "redis";
@@ -70,6 +68,10 @@ import {
   ResponsePaymentError
 } from "../../utils/types";
 import { RptId, RptIdFromString } from "../../utils/pagopa";
+import {
+  ResponseErrorFromValidationErrors,
+  ResponseErrorValidation
+} from "../../utils/responses";
 
 const headerValidationErrorHandler: (
   e: ReadonlyArray<t.ValidationError>
@@ -183,7 +185,7 @@ AsControllerFunction<GetPaymentInfoT> = (
     });
 
     if (error.message === "ESOCKETTIMEDOUT") {
-      return ResponseErrorGatewayTimeout;
+      return ResponseErrorGatewayTimeout();
     } else {
       return ResponsePaymentError(
         PaymentFaultEnum.GENERIC_ERROR,
@@ -458,7 +460,7 @@ AsControllerFunction<ActivatePaymentT> = (
     });
 
     if (error.message === "ESOCKETTIMEDOUT") {
-      return ResponseErrorGatewayTimeout;
+      return ResponseErrorGatewayTimeout();
     } else {
       return ResponsePaymentError(
         PaymentFaultEnum.GENERIC_ERROR,

--- a/src/services/Nm3Service.ts
+++ b/src/services/Nm3Service.ts
@@ -118,7 +118,7 @@ export async function nodoVerifyPaymentNoticeService(
     });
 
     if (error.message === "ESOCKETTIMEDOUT") {
-      return ResponseErrorGatewayTimeout;
+      return ResponseErrorGatewayTimeout();
     } else {
       return ResponsePaymentError(
         PaymentFaultEnum.GENERIC_ERROR,
@@ -321,7 +321,7 @@ export async function nodoActivateIOPaymentService(
     });
 
     if (error.message === "ESOCKETTIMEDOUT") {
-      return ResponseErrorGatewayTimeout;
+      return ResponseErrorGatewayTimeout();
     } else {
       return ResponsePaymentError(
         PaymentFaultEnum.GENERIC_ERROR,

--- a/src/services/Nm3Service.ts
+++ b/src/services/Nm3Service.ts
@@ -32,7 +32,6 @@ import {
   IResponseGatewayError,
   IResponseGatewayTimeout,
   IResponsePartyConfigurationError,
-  IResponseProxyConnectionError,
   IResponseValidationError,
   ResponseGatewayTimeout,
   ResponsePaymentError
@@ -60,7 +59,6 @@ export async function nodoVerifyPaymentNoticeService(
   | IResponseGatewayError
   | IResponsePartyConfigurationError
   | IResponseGatewayTimeout
-  | IResponseProxyConnectionError
   | IResponseSuccessJson<PaymentRequestsGetResponse>
 > {
   logger.info(`GetNodoVerifyPaymentNotice|(nm3) for request|${rptId.asString}`);
@@ -196,7 +194,6 @@ export async function nodoVerifyPaymentNoticeService(
       | IResponseGatewayError
       | IResponsePartyConfigurationError
       | IResponseGatewayTimeout
-      | IResponseProxyConnectionError
       | IResponseSuccessJson<PaymentRequestsGetResponse>;
   } else {
     const responseOrErrorNm3 = PaymentsConverter.getPaymentRequestsGetResponseNm3(

--- a/src/services/Nm3Service.ts
+++ b/src/services/Nm3Service.ts
@@ -4,7 +4,10 @@ import { PathReporter } from "io-ts/lib/PathReporter";
 
 import * as redis from "redis";
 import {
+  IResponseErrorValidation,
   IResponseSuccessJson,
+  ResponseErrorFromValidationErrors,
+  ResponseErrorValidation,
   ResponseSuccessJson
 } from "@pagopa/ts-commons/lib/responses";
 import { CodiceContestoPagamento } from "../../generated/api/CodiceContestoPagamento";
@@ -32,16 +35,12 @@ import {
   IResponseGatewayError,
   IResponseGatewayTimeout,
   IResponsePartyConfigurationError,
-  IResponseValidationError,
+  IResponseErrorValidationFault,
   ResponseGatewayTimeout,
   ResponsePaymentError
 } from "../utils/types";
 import { GatewayFaultEnum } from "../../generated/api/GatewayFault";
-import {
-  ResponseErrorFromValidationErrors,
-  ResponseErrorValidation,
-  responseFromPaymentFault
-} from "../utils/responses";
+import { responseFromPaymentFault } from "../utils/responses";
 import { PagamentiTelematiciPspNm3NodoAsyncClient } from "./pagopa_api/NodoNM3PortClient";
 import * as PaymentsService from "./PaymentsService";
 
@@ -55,7 +54,8 @@ export async function nodoVerifyPaymentNoticeService(
   rptId: GeneralRptId,
   codiceContestoPagamento: CodiceContestoPagamento
 ): Promise<
-  | IResponseValidationError
+  | IResponseErrorValidation
+  | IResponseErrorValidationFault
   | IResponseGatewayError
   | IResponsePartyConfigurationError
   | IResponseGatewayTimeout
@@ -190,7 +190,7 @@ export async function nodoVerifyPaymentNoticeService(
       PaymentFaultEnum.GENERIC_ERROR,
       detailV2
     ) as
-      | IResponseValidationError
+      | IResponseErrorValidationFault
       | IResponseGatewayError
       | IResponsePartyConfigurationError
       | IResponseGatewayTimeout
@@ -259,7 +259,8 @@ export async function nodoActivateIOPaymentService(
   rptId: GeneralRptId,
   amount: ImportoEuroCents
 ): Promise<
-  | IResponseValidationError
+  | IResponseErrorValidation
+  | IResponseErrorValidationFault
   | IResponseGatewayError
   | IResponseSuccessJson<PaymentActivationsPostResponse>
   | IResponseGatewayTimeout
@@ -402,7 +403,7 @@ export async function nodoActivateIOPaymentService(
       detailV2
     ) as
       | IResponseGatewayError
-      | IResponseValidationError
+      | IResponseErrorValidationFault
       | IResponseGatewayTimeout;
   } else {
     const isIdPaymentSaved: boolean = await setNm3PaymentOption(

--- a/src/services/Nm3Service.ts
+++ b/src/services/Nm3Service.ts
@@ -32,6 +32,8 @@ import {
   IResponseGatewayError,
   IResponseGatewayTimeout,
   IResponsePartyConfigurationError,
+  IResponseProxyConnectionError,
+  IResponseValidationError,
   ResponseGatewayTimeout,
   ResponsePaymentError
 } from "../utils/types";
@@ -54,10 +56,12 @@ export async function nodoVerifyPaymentNoticeService(
   rptId: GeneralRptId,
   codiceContestoPagamento: CodiceContestoPagamento
 ): Promise<
+  | IResponseValidationError
   | IResponseGatewayError
   | IResponsePartyConfigurationError
-  | IResponseSuccessJson<PaymentRequestsGetResponse>
   | IResponseGatewayTimeout
+  | IResponseProxyConnectionError
+  | IResponseSuccessJson<PaymentRequestsGetResponse>
 > {
   logger.info(`GetNodoVerifyPaymentNotice|(nm3) for request|${rptId.asString}`);
 
@@ -188,10 +192,12 @@ export async function nodoVerifyPaymentNoticeService(
       PaymentFaultEnum.GENERIC_ERROR,
       detailV2
     ) as
+      | IResponseValidationError
       | IResponseGatewayError
       | IResponsePartyConfigurationError
-      | IResponseSuccessJson<PaymentRequestsGetResponse>
-      | IResponseGatewayTimeout;
+      | IResponseGatewayTimeout
+      | IResponseProxyConnectionError
+      | IResponseSuccessJson<PaymentRequestsGetResponse>;
   } else {
     const responseOrErrorNm3 = PaymentsConverter.getPaymentRequestsGetResponseNm3(
       iverifyPaymentNoticeOutput,
@@ -256,8 +262,8 @@ export async function nodoActivateIOPaymentService(
   rptId: GeneralRptId,
   amount: ImportoEuroCents
 ): Promise<
+  | IResponseValidationError
   | IResponseGatewayError
-  | IResponsePartyConfigurationError
   | IResponseSuccessJson<PaymentActivationsPostResponse>
   | IResponseGatewayTimeout
 > {
@@ -399,7 +405,7 @@ export async function nodoActivateIOPaymentService(
       detailV2
     ) as
       | IResponseGatewayError
-      | IResponsePartyConfigurationError
+      | IResponseValidationError
       | IResponseGatewayTimeout;
   } else {
     const isIdPaymentSaved: boolean = await setNm3PaymentOption(

--- a/src/utils/responses.ts
+++ b/src/utils/responses.ts
@@ -1,0 +1,37 @@
+import { errorsToReadableMessages } from "@pagopa/ts-commons/lib/reporters";
+import * as t from "io-ts";
+import {
+  HttpStatusCodeEnum,
+  IResponseErrorValidation,
+  ResponseErrorGeneric
+} from "@pagopa/ts-commons/lib/responses";
+import { PartyConfigurationFault } from "../../generated/api/PartyConfigurationFault";
+import { PartyTimeoutFault } from "../../generated/api/PartyTimeoutFault";
+
+export const ResponseErrorValidation: (
+  title: string,
+  detail: string | PartyConfigurationFault | PartyTimeoutFault
+) => IResponseErrorValidation = (title, detail) => {
+  // eslint-disable-next-line functional/no-let
+  let responseDetail;
+  if (typeof detail === "string") {
+    responseDetail = `${title}: ${detail}`;
+  } else {
+    responseDetail = detail;
+  }
+  return {
+    ...ResponseErrorGeneric(HttpStatusCodeEnum.HTTP_STATUS_400, title, detail),
+    detail: responseDetail,
+    kind: "IResponseErrorValidation"
+  };
+};
+
+export const ResponseErrorFromValidationErrors: <S, A>(
+  type: t.Type<A, S, unknown>
+) => (
+  errors: ReadonlyArray<t.ValidationError>
+) => // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+IResponseErrorValidation = type => errors => {
+  const detail = errorsToReadableMessages(errors).join("\n");
+  return ResponseErrorValidation(`Invalid ${type.name}`, detail);
+};

--- a/src/utils/responses.ts
+++ b/src/utils/responses.ts
@@ -26,7 +26,7 @@ import { logger } from "./Logger";
 
 export const ResponseErrorValidation: (
   title: string,
-  detail: string | PartyConfigurationFaultEnum
+  detail: string | ValidationFaultEnum
 ) => IResponseValidationError = (title, detail) => {
   // eslint-disable-next-line functional/no-let
   let responseDetail;
@@ -77,7 +77,7 @@ export const responseFromPaymentFault: (
   ) {
     return ResponseErrorValidation(
       detail,
-      (detail_v2 as unknown) as GatewayFaultEnum
+      (detail_v2 as unknown) as ValidationFaultEnum
     );
   } else if (
     Object.values(GatewayFaultEnum).includes(

--- a/src/utils/responses.ts
+++ b/src/utils/responses.ts
@@ -8,6 +8,7 @@ import { PaymentFaultEnum } from "../../generated/api/PaymentFault";
 import { PaymentFaultV2Enum } from "../../generated/api/PaymentFaultV2";
 import { GatewayFaultEnum } from "../../generated/api/GatewayFault";
 import { ValidationFaultEnum } from "../../generated/api/ValidationFault";
+import { PaymentStatusFaultEnum } from "../../generated/api/PaymentStatusFault";
 import {
   IResponseGatewayError,
   IResponseGatewayTimeout,
@@ -15,7 +16,9 @@ import {
   IResponseErrorValidationFault,
   ResponseGatewayTimeout,
   ResponsePartyConfigurationError,
-  ResponsePaymentError
+  ResponsePaymentError,
+  IResponsePaymentStatusFaultError,
+  ResponsePaymentStatusFaultError
 } from "./types";
 import { logger } from "./Logger";
 
@@ -41,6 +44,7 @@ export const responseFromPaymentFault: (
   detail: PaymentFaultEnum,
   detail_v2: PaymentFaultV2Enum
 ) =>
+  | IResponsePaymentStatusFaultError
   | IResponsePartyConfigurationError
   | IResponseErrorValidationFault
   | IResponseGatewayError
@@ -62,6 +66,15 @@ export const responseFromPaymentFault: (
     return ResponseErrorValidationFault(
       detail,
       (detail_v2 as unknown) as ValidationFaultEnum
+    );
+  } else if (
+    Object.values(PaymentStatusFaultEnum).includes(
+      (detail_v2 as unknown) as PaymentStatusFaultEnum
+    )
+  ) {
+    return ResponsePaymentStatusFaultError(
+      detail,
+      (detail_v2 as unknown) as PaymentStatusFaultEnum
     );
   } else if (
     Object.values(GatewayFaultEnum).includes(

--- a/src/utils/responses.ts
+++ b/src/utils/responses.ts
@@ -2,16 +2,28 @@ import { errorsToReadableMessages } from "@pagopa/ts-commons/lib/reporters";
 import * as t from "io-ts";
 import {
   HttpStatusCodeEnum,
-  IResponseErrorValidation,
   ResponseErrorGeneric
 } from "@pagopa/ts-commons/lib/responses";
-import { PartyConfigurationFault } from "../../generated/api/PartyConfigurationFault";
+import { PartyConfigurationFaultEnum } from "../../generated/api/PartyConfigurationFault";
 import { PartyTimeoutFault } from "../../generated/api/PartyTimeoutFault";
+import { PaymentFaultEnum } from "../../generated/api/PaymentFault";
+import { PaymentFaultV2Enum } from "../../generated/api/PaymentFaultV2";
+import { GatewayFaultEnum } from "../../generated/api/GatewayFault";
+import { PartyConnectionFaultEnum } from "../../generated/api/PartyConnectionFault";
+import {
+  IResponseGatewayError,
+  IResponseGatewayTimeout,
+  IResponsePartyConfigurationError,
+  IResponseProxyConnectionError,
+  ResponseGatewayTimeout,
+  ResponsePaymentError,
+  ResponseProxyConnectionError
+} from "./types";
 
 export const ResponseErrorValidation: (
   title: string,
-  detail: string | PartyConfigurationFault | PartyTimeoutFault
-) => IResponseErrorValidation = (title, detail) => {
+  detail: string | PartyConfigurationFaultEnum
+) => IResponsePartyConfigurationError = (title, detail) => {
   // eslint-disable-next-line functional/no-let
   let responseDetail;
   if (typeof detail === "string") {
@@ -22,7 +34,7 @@ export const ResponseErrorValidation: (
   return {
     ...ResponseErrorGeneric(HttpStatusCodeEnum.HTTP_STATUS_400, title, detail),
     detail: responseDetail,
-    kind: "IResponseErrorValidation"
+    kind: "IResponsePartyConfigurationError"
   };
 };
 
@@ -31,7 +43,52 @@ export const ResponseErrorFromValidationErrors: <S, A>(
 ) => (
   errors: ReadonlyArray<t.ValidationError>
 ) => // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-IResponseErrorValidation = type => errors => {
+IResponsePartyConfigurationError = type => errors => {
   const detail = errorsToReadableMessages(errors).join("\n");
   return ResponseErrorValidation(`Invalid ${type.name}`, detail);
+};
+
+export const responseFromPaymentFault: (
+  detail: PaymentFaultEnum,
+  detail_v2: PaymentFaultV2Enum
+) =>
+  | IResponsePartyConfigurationError
+  | IResponseGatewayError
+  | IResponseGatewayTimeout
+  | IResponseProxyConnectionError = (detail, detail_v2) => {
+  if (
+    Object.values(PartyConfigurationFaultEnum).includes(
+      (detail_v2 as unknown) as PartyConfigurationFaultEnum
+    )
+  ) {
+    return ResponseErrorValidation(
+      detail,
+      (detail_v2 as unknown) as PartyConfigurationFaultEnum
+    );
+  } else if (
+    Object.values(GatewayFaultEnum).includes(
+      (detail_v2 as unknown) as GatewayFaultEnum
+    )
+  ) {
+    return ResponsePaymentError(
+      detail,
+      (detail_v2 as unknown) as GatewayFaultEnum
+    );
+  } else if (
+    Object.values(PartyTimeoutFault).includes(
+      (detail_v2 as unknown) as PartyTimeoutFault
+    )
+  ) {
+    return ResponseGatewayTimeout((detail_v2 as unknown) as PartyTimeoutFault);
+  } else if (
+    Object.values(PartyConnectionFaultEnum).includes(
+      (detail_v2 as unknown) as PartyConnectionFaultEnum
+    )
+  ) {
+    return ResponseProxyConnectionError(
+      (detail_v2 as unknown) as PartyConnectionFaultEnum
+    );
+  } else {
+    throw new Error("unmapped payment fault v2");
+  }
 };

--- a/src/utils/responses.ts
+++ b/src/utils/responses.ts
@@ -2,22 +2,29 @@ import {
   HttpStatusCodeEnum,
   ResponseErrorGeneric
 } from "@pagopa/ts-commons/lib/responses";
-import { PartyConfigurationFaultEnum } from "../../generated/api/PartyConfigurationFault";
-import { PartyTimeoutFaultEnum } from "../../generated/api/PartyTimeoutFault";
+import * as t from "io-ts";
+import * as E from "fp-ts/lib/Either";
+import * as A from "fp-ts/lib/Array";
+import { flow, pipe } from "fp-ts/lib/function";
+import { PartyConfigurationFault } from "../../generated/api/PartyConfigurationFault";
+import { PartyTimeoutFault } from "../../generated/api/PartyTimeoutFault";
 import { PaymentFaultEnum } from "../../generated/api/PaymentFault";
 import { PaymentFaultV2Enum } from "../../generated/api/PaymentFaultV2";
-import { GatewayFaultEnum } from "../../generated/api/GatewayFault";
-import { ValidationFaultEnum } from "../../generated/api/ValidationFault";
-import { PaymentStatusFaultEnum } from "../../generated/api/PaymentStatusFault";
+import { GatewayFault } from "../../generated/api/GatewayFault";
 import {
+  ValidationFault,
+  ValidationFaultEnum
+} from "../../generated/api/ValidationFault";
+import { PaymentStatusFault } from "../../generated/api/PaymentStatusFault";
+import {
+  IResponseErrorValidationFault,
   IResponseGatewayError,
   IResponseGatewayTimeout,
   IResponsePartyConfigurationError,
-  IResponseErrorValidationFault,
+  IResponsePaymentStatusFaultError,
   ResponseGatewayTimeout,
   ResponsePartyConfigurationError,
   ResponsePaymentError,
-  IResponsePaymentStatusFaultError,
   ResponsePaymentStatusFaultError
 } from "./types";
 import { logger } from "./Logger";
@@ -40,61 +47,62 @@ export const ResponseErrorValidationFault: (
   };
 };
 
-export const responseFromPaymentFault: (
-  detail: PaymentFaultEnum,
-  detail_v2: PaymentFaultV2Enum
-) =>
+type FaultResponse =
   | IResponsePaymentStatusFaultError
   | IResponsePartyConfigurationError
   | IResponseErrorValidationFault
   | IResponseGatewayError
-  | IResponseGatewayTimeout = (detail, detail_v2) => {
-  if (
-    Object.values(PartyConfigurationFaultEnum).includes(
-      (detail_v2 as unknown) as PartyConfigurationFaultEnum
+  | IResponseGatewayTimeout;
+
+export const responseFromPaymentFault: (
+  detail: PaymentFaultEnum,
+  detail_v2: PaymentFaultV2Enum
+) => FaultResponse = (detail, detail_v2) => {
+  // eslint-disable-next-line functional/prefer-readonly-type
+  const parsers: Array<t.Decode<PaymentFaultV2Enum, FaultResponse>> = [
+    flow(
+      PartyConfigurationFault.decode,
+      E.map(v => ResponsePartyConfigurationError(detail, v))
+    ),
+    flow(
+      ValidationFault.decode,
+      E.map(v => ResponseErrorValidationFault(detail, v))
+    ),
+    flow(
+      PaymentStatusFault.decode,
+      E.map(v => ResponsePaymentStatusFaultError(detail, v))
+    ),
+    flow(
+      GatewayFault.decode,
+      E.map(v => ResponsePaymentError(detail, v))
+    ),
+    flow(
+      PartyTimeoutFault.decode,
+      E.map(v => ResponseGatewayTimeout(v))
     )
-  ) {
-    return ResponsePartyConfigurationError(
-      detail,
-      (detail_v2 as unknown) as PartyConfigurationFaultEnum
+  ];
+
+  const reducer: (
+    current: E.Either<FaultResponse, PaymentFaultV2Enum>,
+    decoder: t.Decode<PaymentFaultV2Enum, FaultResponse>
+  ) => E.Either<FaultResponse, PaymentFaultV2Enum> = (current, decoder) =>
+    pipe(
+      current,
+      E.chain((d: PaymentFaultV2Enum) =>
+        pipe(
+          decoder(d),
+          E.swap,
+          E.map(_ => d)
+        )
+      )
     );
-  } else if (
-    Object.values(ValidationFaultEnum).includes(
-      (detail_v2 as unknown) as ValidationFaultEnum
-    )
-  ) {
-    return ResponseErrorValidationFault(
-      detail,
-      (detail_v2 as unknown) as ValidationFaultEnum
-    );
-  } else if (
-    Object.values(PaymentStatusFaultEnum).includes(
-      (detail_v2 as unknown) as PaymentStatusFaultEnum
-    )
-  ) {
-    return ResponsePaymentStatusFaultError(
-      detail,
-      (detail_v2 as unknown) as PaymentStatusFaultEnum
-    );
-  } else if (
-    Object.values(GatewayFaultEnum).includes(
-      (detail_v2 as unknown) as GatewayFaultEnum
-    )
-  ) {
-    return ResponsePaymentError(
-      detail,
-      (detail_v2 as unknown) as GatewayFaultEnum
-    );
-  } else if (
-    Object.values(PartyTimeoutFaultEnum).includes(
-      (detail_v2 as unknown) as PartyTimeoutFaultEnum
-    )
-  ) {
-    return ResponseGatewayTimeout(
-      (detail_v2 as unknown) as PartyTimeoutFaultEnum
-    );
-  } else {
-    logger.error(`unmapped detail_v2: ${detail_v2}`);
-    throw new Error(`unmapped detail_v2: ${detail_v2}`);
-  }
+
+  return pipe(
+    parsers,
+    A.reduce(E.right(detail_v2), reducer),
+    E.fold(t.identity, (variant: PaymentFaultV2Enum) => {
+      logger.error(`unmapped detail_v2: ${variant}`);
+      throw new Error(`unmapped detail_v2: ${variant}`);
+    })
+  );
 };

--- a/src/utils/responses.ts
+++ b/src/utils/responses.ts
@@ -9,18 +9,15 @@ import { PartyTimeoutFaultEnum } from "../../generated/api/PartyTimeoutFault";
 import { PaymentFaultEnum } from "../../generated/api/PaymentFault";
 import { PaymentFaultV2Enum } from "../../generated/api/PaymentFaultV2";
 import { GatewayFaultEnum } from "../../generated/api/GatewayFault";
-import { PartyConnectionFaultEnum } from "../../generated/api/PartyConnectionFault";
 import { ValidationFaultEnum } from "../../generated/api/ValidationFault";
 import {
   IResponseGatewayError,
   IResponseGatewayTimeout,
   IResponsePartyConfigurationError,
-  IResponseProxyConnectionError,
   IResponseValidationError,
   ResponseGatewayTimeout,
   ResponsePartyConfigurationError,
-  ResponsePaymentError,
-  ResponseProxyConnectionError
+  ResponsePaymentError
 } from "./types";
 import { logger } from "./Logger";
 
@@ -59,8 +56,7 @@ export const responseFromPaymentFault: (
   | IResponsePartyConfigurationError
   | IResponseValidationError
   | IResponseGatewayError
-  | IResponseGatewayTimeout
-  | IResponseProxyConnectionError = (detail, detail_v2) => {
+  | IResponseGatewayTimeout = (detail, detail_v2) => {
   if (
     Object.values(PartyConfigurationFaultEnum).includes(
       (detail_v2 as unknown) as PartyConfigurationFaultEnum
@@ -95,14 +91,6 @@ export const responseFromPaymentFault: (
   ) {
     return ResponseGatewayTimeout(
       (detail_v2 as unknown) as PartyTimeoutFaultEnum
-    );
-  } else if (
-    Object.values(PartyConnectionFaultEnum).includes(
-      (detail_v2 as unknown) as PartyConnectionFaultEnum
-    )
-  ) {
-    return ResponseProxyConnectionError(
-      (detail_v2 as unknown) as PartyConnectionFaultEnum
     );
   } else {
     logger.error(`unmapped detail_v2: ${detail_v2}`);

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -8,6 +8,7 @@ import {
   HttpStatusCodeEnum,
   IResponse,
   IResponseErrorNotFound,
+  IResponseErrorValidation,
   IResponseSuccessJson,
   ProblemJson
 } from "@pagopa/ts-commons/lib/responses";
@@ -27,8 +28,10 @@ import { RptId } from "./pagopa";
 
 export type AsControllerResponseType<T> = T extends IResponseType<200, infer R>
   ? IResponseSuccessJson<R>
+  : T extends IResponseType<400, ProblemJson>
+  ? IResponseErrorValidation
   : T extends IResponseType<404, ValidationFaultPaymentProblemJson>
-  ? IResponseValidationError
+  ? IResponseErrorValidationFault
   : T extends IResponseType<404, ProblemJson>
   ? IResponseErrorNotFound
   : T extends IResponseType<502, GatewayFaultPaymentProblemJson>
@@ -74,7 +77,9 @@ export const ResponsePartyConfigurationError = (
   };
 };
 
-export type IResponseValidationError = IResponse<"IResponseValidationError">;
+export type IResponseErrorValidationFault = IResponse<
+  "IResponseErrorValidationFault"
+>;
 
 export type IResponseGatewayError = IResponse<"IResponseGatewayError">;
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -29,7 +29,7 @@ import { RptId } from "./pagopa";
 
 export type AsControllerResponseType<T> = T extends IResponseType<200, infer R>
   ? IResponseSuccessJson<R>
-  : T extends IResponseType<400, ValidationFaultPaymentProblemJson>
+  : T extends IResponseType<404, ValidationFaultPaymentProblemJson>
   ? IResponseValidationError
   : T extends IResponseType<404, ProblemJson>
   ? IResponseErrorNotFound

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -27,7 +27,7 @@ export type AsControllerResponseType<T> = T extends IResponseType<200, infer R>
   ? IResponseErrorNotFound
   : T extends IResponseType<500, ProblemJson>
   ? IResponseErrorInternal
-  : T extends IResponseType<424, PaymentProblemJson>
+  : T extends IResponseType<502, PaymentProblemJson>
   ? IResponsePaymentInternalError
   : T extends IResponseType<504, PaymentProblemJson>
   ? IResponseErrorGatewayTimeout
@@ -42,7 +42,7 @@ export type IResponsePaymentInternalError = IResponse<"IResponseErrorInternal">;
 type HttpCode = number & WithinRangeInteger<100, 599>;
 
 /**
- * Returns a 424 with json response.
+ * Returns a 502 with json response.
  */
 export const ResponsePaymentError = (
   detail: PaymentFaultEnum,
@@ -51,14 +51,14 @@ export const ResponsePaymentError = (
   const problem: PaymentProblemJson = {
     detail,
     detail_v2: detailV2,
-    status: HttpStatusCodeEnum.HTTP_STATUS_424 as HttpCode,
+    status: HttpStatusCodeEnum.HTTP_STATUS_502 as HttpCode,
     title: "pagoPA service error"
   };
   return {
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     apply: res =>
       res
-        .status(HttpStatusCodeEnum.HTTP_STATUS_424)
+        .status(HttpStatusCodeEnum.HTTP_STATUS_502)
         .set("Content-Type", "application/problem+json")
         .json(problem),
     kind: "IResponseErrorInternal"

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -20,8 +20,6 @@ import {
 import { PartyTimeoutFaultPaymentProblemJson } from "../../generated/api/PartyTimeoutFaultPaymentProblemJson";
 import { PartyConfigurationFaultPaymentProblemJson } from "../../generated/api/PartyConfigurationFaultPaymentProblemJson";
 import { GatewayFaultPaymentProblemJson } from "../../generated/api/GatewayFaultPaymentProblemJson";
-import { PartyConnectionFaultPaymentProblemJson } from "../../generated/api/PartyConnectionFaultPaymentProblemJson";
-import { PartyConnectionFault } from "../../generated/api/PartyConnectionFault";
 import { GatewayFaultEnum } from "../../generated/api/GatewayFault";
 import { ValidationFaultPaymentProblemJson } from "../../generated/api/ValidationFaultPaymentProblemJson";
 import { PartyConfigurationFaultEnum } from "../../generated/api/PartyConfigurationFault";
@@ -39,8 +37,6 @@ export type AsControllerResponseType<T> = T extends IResponseType<200, infer R>
   ? IResponsePartyConfigurationError
   : T extends IResponseType<504, PartyTimeoutFaultPaymentProblemJson>
   ? IResponseGatewayTimeout
-  : T extends IResponseType<598, PartyConnectionFaultPaymentProblemJson>
-  ? IResponseProxyConnectionError
   : never;
 
 export type AsControllerFunction<T> = (
@@ -130,33 +126,6 @@ export const ResponseGatewayTimeout: (
       .json(problem);
   },
   kind: "IResponseErrorGatewayTimeout"
-});
-
-export type IResponseProxyConnectionError = IResponse<
-  "IResponseProxyConnectionError"
->;
-
-/**
- * Returns a 598 response
- */
-export const ResponseProxyConnectionError: (
-  detail: PartyConnectionFault
-) => IResponseProxyConnectionError = detail => ({
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  apply: res => {
-    const problem: PartyConnectionFaultPaymentProblemJson = {
-      detail: PaymentFaultEnum.GENERIC_ERROR,
-      detail_v2: detail,
-      status: 598 as HttpCode,
-      title: "pagoPA connection error"
-    };
-
-    res
-      .status(598)
-      .set("Content-Type", "application/problem+json")
-      .json(problem);
-  },
-  kind: "IResponseProxyConnectionError"
 });
 
 const GeneralRptId = t.interface({


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

 * Update Swagger API spec for `pagopa-proxy`

#### Motivation and Context

This PR makes monitoring easier while providing a stricter API specification.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.


depends on pagopa/pagopa-infra#236