### PR TITLE
fix:  ResponseErrorNotFound for ActivationStatus

### DIFF
--- a/api-spec/api-pagopa-proxy.yaml
+++ b/api-spec/api-pagopa-proxy.yaml
@@ -123,7 +123,7 @@ paths:
         '404':
           description: Activation status not found
           schema:
-            $ref: "#/definitions/ValidationFaultPaymentProblemJson"
+            $ref: "#/definitions/ProblemJson"
         "502":
           description: PagoPA services are not available or request is rejected by PagoPa
           schema:

--- a/src/controllers/restful/PaymentController.ts
+++ b/src/controllers/restful/PaymentController.ts
@@ -13,6 +13,7 @@ import { TypeofApiResponse } from "@pagopa/ts-commons/lib/requests";
 import {
   IResponseErrorValidation,
   ResponseErrorFromValidationErrors,
+  ResponseErrorNotFound,
   ResponseErrorValidation,
   ResponseSuccessJson
 } from "@pagopa/ts-commons/lib/responses";
@@ -746,7 +747,7 @@ const getGetActivationStatusController: (
   const maybeIdPayment = maybeIdPaymentOrError.right;
 
   if (O.isNone(maybeIdPayment)) {
-    return ResponseErrorValidation("Not found", "getActivationStatus");
+    return ResponseErrorNotFound("Not found", "getActivationStatus");
   }
 
   const idPayment = maybeIdPayment.value;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- set 404 instead 400 when idPayment not found;

#### Motivation and Context

The goal of this PR is to restore the status code 404 for the api GetActivation when the payment id is not found.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
