### PR TITLE
CHK-573 Add optional dueDate in PaymentRequestsGetResponse

### DIFF
--- a/api-spec/api-for-checkout.yaml
+++ b/api-spec/api-for-checkout.yaml
@@ -143,7 +143,31 @@ definitions:
   PaymentActivationsPostResponse:
     $ref: "https://raw.githubusercontent.com/pagopa/io-pagopa-proxy/v1.1.1/api_pagopa.yaml#/definitions/PaymentActivationsPostResponse"
   PaymentRequestsGetResponse:
-    $ref: "https://raw.githubusercontent.com/pagopa/io-pagopa-proxy/v1.1.1/api_pagopa.yaml#/definitions/PaymentRequestsGetResponse"
+    type: object
+    title: PaymentRequestsGetResponse
+    description: Define the response to send to CD App containing payment information
+    properties:
+      importoSingoloVersamento:
+        $ref: '#/definitions/ImportoEuroCents'
+      codiceContestoPagamento:
+        $ref: '#/definitions/CodiceContestoPagamento'
+      ibanAccredito:
+        $ref: '#/definitions/Iban'
+      causaleVersamento:
+        type: string
+        minLength: 1
+        maxLength: 140
+      enteBeneficiario:
+        $ref: '#/definitions/EnteBeneficiario'
+      spezzoniCausaleVersamento:
+        $ref: '#/definitions/SpezzoniCausaleVersamento'
+      dueDate:
+        type: string
+        format: date
+        example: "2021-07-31"    
+    required:
+      - importoSingoloVersamento
+      - codiceContestoPagamento
   RptId:
     $ref: "https://raw.githubusercontent.com/pagopa/io-pagopa-proxy/v1.1.1/api_pagopa.yaml#/definitions/RptId"
   SpezzoneStrutturatoCausaleVersamento:

--- a/api-spec/api-for-checkout.yaml
+++ b/api-spec/api-for-checkout.yaml
@@ -163,7 +163,7 @@ definitions:
         $ref: '#/definitions/SpezzoniCausaleVersamento'
       dueDate:
         type: string
-        format: date
+        format: date-time
         example: "2025-07-31T00:00:00.000Z"    
     required:
       - importoSingoloVersamento

--- a/api-spec/api-for-checkout.yaml
+++ b/api-spec/api-for-checkout.yaml
@@ -164,7 +164,7 @@ definitions:
       dueDate:
         type: string
         format: date
-        example: "2021-07-31"    
+        example: "2025-07-31T00:00:00.000Z"    
     required:
       - importoSingoloVersamento
       - codiceContestoPagamento

--- a/api-spec/api-for-io.yaml
+++ b/api-spec/api-for-io.yaml
@@ -297,6 +297,10 @@ definitions:
         $ref: '#/definitions/EnteBeneficiario'
       spezzoniCausaleVersamento:
         $ref: '#/definitions/SpezzoniCausaleVersamento'
+      dueDate:
+        type: string
+        format: date
+        example: "2021-07-31"    
     required:
       - importoSingoloVersamento
       - codiceContestoPagamento

--- a/api-spec/api-for-io.yaml
+++ b/api-spec/api-for-io.yaml
@@ -299,7 +299,7 @@ definitions:
         $ref: '#/definitions/SpezzoniCausaleVersamento'
       dueDate:
         type: string
-        format: date
+        format: date-time
         example: "2025-07-31T00:00:00.000Z"    
     required:
       - importoSingoloVersamento

--- a/api-spec/api-for-io.yaml
+++ b/api-spec/api-for-io.yaml
@@ -300,7 +300,7 @@ definitions:
       dueDate:
         type: string
         format: date
-        example: "2021-07-31"    
+        example: "2025-07-31T00:00:00.000Z"    
     required:
       - importoSingoloVersamento
       - codiceContestoPagamento

--- a/api-spec/api-pagopa-proxy.yaml
+++ b/api-spec/api-pagopa-proxy.yaml
@@ -509,7 +509,7 @@ definitions:
         $ref: '#/definitions/SpezzoniCausaleVersamento'
       dueDate:
         type: string
-        format: date
+        format: date-time
         example: "2025-07-31T00:00:00.000Z"  
     required:
       - importoSingoloVersamento

--- a/api-spec/api-pagopa-proxy.yaml
+++ b/api-spec/api-pagopa-proxy.yaml
@@ -507,6 +507,10 @@ definitions:
         $ref: '#/definitions/EnteBeneficiario'
       spezzoniCausaleVersamento:
         $ref: '#/definitions/SpezzoniCausaleVersamento'
+      dueDate:
+        type: string
+        format: date
+        example: "2021-07-31"  
     required:
       - importoSingoloVersamento
       - codiceContestoPagamento

--- a/api-spec/api-pagopa-proxy.yaml
+++ b/api-spec/api-pagopa-proxy.yaml
@@ -510,7 +510,7 @@ definitions:
       dueDate:
         type: string
         format: date
-        example: "2021-07-31"  
+        example: "2025-07-31T00:00:00.000Z"  
     required:
       - importoSingoloVersamento
       - codiceContestoPagamento

--- a/io-pagopa-node-mock/DockerfileTMP
+++ b/io-pagopa-node-mock/DockerfileTMP
@@ -1,4 +1,4 @@
-FROM node:10.14.2-alpine
+FROM node:14.16.0-alpine
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash ca-certificates git openssh openssl

--- a/src/utils/PaymentsConverter.ts
+++ b/src/utils/PaymentsConverter.ts
@@ -213,7 +213,8 @@ export function getPaymentRequestsGetResponseNm3(
               70
             ),
             denomUnitOperBeneficiario: verifyPaymentNoticeResponse.officeName
-          }
+          },
+          dueDate: paymentOptionDescription.dueDate
         }
       : undefined
   );

--- a/src/utils/__tests__/MockedData.ts
+++ b/src/utils/__tests__/MockedData.ts
@@ -10,6 +10,7 @@ import * as E from "fp-ts/Either";
 import { RptId } from "../pagopa";
 import { activateIOPaymentRes_element_nfpsp } from "../../../generated/nodeNm3io/activateIOPaymentRes_element_nfpsp";
 import { ValidationError } from "io-ts";
+import { verifyPaymentNoticeRes_element_nfpsp } from "../../../generated/nodeNm3psp/verifyPaymentNoticeRes_element_nfpsp";
 
 // tslint:disable:no-identical-functions
 
@@ -490,3 +491,49 @@ export const activateIOPaymentResOutputWhithEnte = pipe(activateIOPaymentRes_ele
         )}`
       );
     }));
+
+    export const verifyPaymentNoticeWithDueDate = pipe(verifyPaymentNoticeRes_element_nfpsp
+      .decode({
+        outcome: "OK",
+        paymentDescription: "Test causale",
+        fiscalCodePA: "77777777777",
+        companyName: "Company Name",
+        paymentList : {
+          paymentOptionDescription : [
+            { "amount" : 100,
+              "options" : "EQ",
+              "dueDate" : "2021-07-31"}
+          ]
+        }
+      }),
+      E.getOrElseW((errors: readonly ValidationError[]) => {
+        throw Error(
+          `Invalid verifyPaymentNoticeRes_element_nfpsp to decode: ${reporters.readableReport(
+            errors
+          )}`
+        );
+      }));
+    
+    export const verifyPaymentNoticeWithoutDueDate = pipe(verifyPaymentNoticeRes_element_nfpsp
+      .decode({
+        outcome: "OK",
+        paymentDescription: "Test causale",
+        fiscalCodePA: "77777777777",
+        companyName: "Company Name",
+        paymentList : {
+          paymentOptionDescription : [
+            { 
+              "amount" : 100,
+              "options" : "EQ"
+            }
+          ]
+        }
+      }),
+      E.getOrElseW((errors: readonly ValidationError[]) => {
+        throw Error(
+          `Invalid verifyPaymentNoticeRes_element_nfpsp to decode: ${reporters.readableReport(
+            errors
+          )}`
+        );
+      }));      
+  

--- a/src/utils/__tests__/PaymentConverter.test.ts
+++ b/src/utils/__tests__/PaymentConverter.test.ts
@@ -9,6 +9,7 @@ import * as PaymentsConverter from "../PaymentsConverter";
 import * as MockedData from "./MockedData";
 import { MOCK_CLIENT_ID } from "./MockedData";
 import { FaultCategoryEnum } from "../../../generated/api/FaultCategory";
+import { CodiceContestoPagamento } from "../../../generated/api/CodiceContestoPagamento";
 
 describe("getNodoVerificaRPTInput", () => {
   it("should return a correct NodoVerificaRPTInput with auxDigit=0", () => {
@@ -918,4 +919,45 @@ describe("getPaymentNoticeNumberAsString", () => {
    
     expect(noticeNumberAsString).toBe("30123456789012300");
   });
+});
+
+describe("getVerifyPaymentNoticeResponse", () => {
+
+  it("should convert verifyPaymentNoticeRes_element_nfpsp with dueDate in getPaymentRequestsGetResponseNm3", () => {
+
+    const errorOrVerifyPaymentNoticeResponse = PaymentsConverter.getPaymentRequestsGetResponseNm3(
+      MockedData.verifyPaymentNoticeWithDueDate, 
+      "8447a9f0746811e89a8d5d4209060ab0" as CodiceContestoPagamento
+    );
+    expect(isRight(errorOrVerifyPaymentNoticeResponse)).toBeTruthy();
+    if (!isRight(errorOrVerifyPaymentNoticeResponse)) {
+      return;
+    }
+
+    const dueDate : Date | undefined = errorOrVerifyPaymentNoticeResponse.right.dueDate
+    ? errorOrVerifyPaymentNoticeResponse.right.dueDate : undefined;
+
+    expect(
+      dueDate?.toISOString()
+    ).toBe("2021-07-31T00:00:00.000Z");
+   });
+
+   it("should convert verifyPaymentNoticeRes_element_nfpsp without dueDate in getPaymentRequestsGetResponseNm3", () => {
+
+    const errorOrVerifyPaymentNoticeResponse = PaymentsConverter.getPaymentRequestsGetResponseNm3(
+      MockedData.verifyPaymentNoticeWithoutDueDate, 
+      "8447a9f0746811e89a8d5d4209060ab0" as CodiceContestoPagamento
+    );
+    expect(isRight(errorOrVerifyPaymentNoticeResponse)).toBeTruthy();
+    if (!isRight(errorOrVerifyPaymentNoticeResponse)) {
+      return;
+    }
+
+    const dueDate : Date | undefined = errorOrVerifyPaymentNoticeResponse.right.dueDate
+    ? errorOrVerifyPaymentNoticeResponse.right.dueDate : undefined;
+
+    expect(
+      dueDate?.toISOString()
+    ).toBeUndefined();
+   });
 });


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- add optional `dueDate` in `PaymentRequestsGetResponse`

#### Motivation and Context

The goal of this PR is to add `dueDate` in verify step, according to https://raw.githubusercontent.com/pagopa/pagopa-api/develop/nodo/nodeForPsp.wsdl.

#### How Has This Been Tested?

unit test

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
