### PR TITLE
refactor(opex): disable opex alerts

### DIFF
--- a/.opex/api-for-checkout/env/prod/config.yaml
+++ b/.opex/api-for-checkout/env/prod/config.yaml
@@ -11,6 +11,8 @@ overrides:
     - api.platform.pagopa.it
   endpoints:
     /checkout/payments/v1/payment-requests/{rptId}:
-      response_time_threshold: 5
+      response_time_threshold: 15
+      availability_threshold: 0
     /checkout/payments/v1/payment-activations:
-      response_time_threshold: 5
+      response_time_threshold: 15
+      availability_threshold: 0

--- a/.opex/api-for-io/env/prod/config.yaml
+++ b/.opex/api-for-io/env/prod/config.yaml
@@ -11,7 +11,8 @@ overrides:
     - api.platform.pagopa.it
   endpoints:
     /checkout/auth/payments/v1/payment-requests/{rpt_id_from_string}:
-      response_time_threshold: 5
-      availability_threshold: 0.25
+      response_time_threshold: 15
+      availability_threshold: 0
     /checkout/auth/payments/v1/payment-activations:
-      response_time_threshold: 5
+      response_time_threshold: 15
+      availability_threshold: 0


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

* disable OpEx alerts

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

For this project OpEx alerts require more thorough tuning that cannot be made possible at this time.
As a workaround, we are temporarily disabling them and leaning on other alerts declared at the infra level.

Note that the value chosen for the timings timeout (here **15**) is arbitrary, as any request over 10s would be terminated by the APIM.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
